### PR TITLE
Dockerfile: use buildkit platform args

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,0 +1,81 @@
+name: default
+
+on: push
+
+env:
+  BR_VERSION: "2020.11"
+  UNBOUND_VERSION: "1.13.0"
+  DOCKER_CLI_EXPERIMENTAL: enabled
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        PLATFORM: [linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6]
+
+    steps:
+      - name: docker install
+        run: curl -fsSL get.docker.com | sh
+
+      - name: source checkout
+        uses: actions/checkout@v1
+
+      - name: buildx create
+        run: docker buildx create --use --driver docker-container
+
+      - name: image build
+        run: docker buildx build . --pull --build-arg BR_VERSION --platform ${{ matrix.PLATFORM }} --tag ${GITHUB_REPOSITORY} --load
+
+      - name: qemu register
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+      - name: image test
+        run: |
+          docker run --rm -d --name unbound-dnscrypt ${GITHUB_REPOSITORY}
+          docker exec unbound-dnscrypt dig sigok.verteiltesysteme.net @127.0.0.1 +dnssec | tee /dev/stderr | grep -q NOERROR
+          docker exec unbound-dnscrypt dig sigfail.verteiltesysteme.net @127.0.0.1 +dnssec | tee /dev/stderr | grep -q SERVFAIL
+          docker stop unbound-dnscrypt
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: docker install
+        run: curl -fsSL get.docker.com | sh
+
+      - name: source checkout
+        uses: actions/checkout@v1
+
+      - name: github login
+        run: echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+
+      - name: dockerhub login
+        run: echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login docker.io -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+      
+      - name: buildx create
+        run: docker buildx create --use --driver docker-container
+
+      - name: manifest build
+        run: >-
+            docker buildx build . --pull --push
+            --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+            --build-arg BR_VERSION
+            --label "org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+            --label "org.opencontainers.image.version=${UNBOUND_VERSION}"
+            --label "org.opencontainers.image.revision=$(git describe --tags --always --dirty)"
+            --tag docker.io/${{ secrets.DOCKERHUB_REPOSITORY }}:${UNBOUND_VERSION}
+            --tag docker.io/${{ secrets.DOCKERHUB_REPOSITORY }}:latest
+            --tag ghcr.io/${GITHUB_REPOSITORY}:${UNBOUND_VERSION}
+            --tag ghcr.io/${GITHUB_REPOSITORY}:latest
+
+      - name: dockerhub description
+        uses: peter-evans/dockerhub-description@v2.1.0
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          DOCKERHUB_REPOSITORY: ${{ secrets.DOCKERHUB_REPOSITORY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,19 @@
-ARG ARCH=amd64
+ARG BR_VERSION=2020.11
 
-FROM klutchell/buildroot-rootfs-$ARCH:2020.11 as buildroot
+# hadolint ignore=DL3029
+FROM --platform=$BUILDPLATFORM klutchell/buildroot-rootfs-amd64:$BR_VERSION as rootfs-amd64
+
+# hadolint ignore=DL3029
+FROM --platform=$BUILDPLATFORM klutchell/buildroot-rootfs-arm64:$BR_VERSION as rootfs-arm64
+
+# hadolint ignore=DL3029
+FROM --platform=$BUILDPLATFORM klutchell/buildroot-rootfs-arm32v7:$BR_VERSION as rootfs-armv7
+
+# hadolint ignore=DL3029
+FROM --platform=$BUILDPLATFORM klutchell/buildroot-rootfs-arm32v6:$BR_VERSION as rootfs-armv6
+
+# hadolint ignore=DL3006
+FROM rootfs-$TARGETARCH$TARGETVARIANT as build
 
 COPY package ./package
 
@@ -23,7 +36,7 @@ RUN tar xpf /home/br-user/output/images/rootfs.tar -C /rootfs
 
 FROM scratch
 
-COPY --from=buildroot rootfs/ /
+COPY --from=build rootfs/ /
 
 ENTRYPOINT [ "unbound" ]
 

--- a/README.md
+++ b/README.md
@@ -19,22 +19,32 @@ Simply pulling `klutchell/unbound-dnscrypt` should retrieve the correct image fo
 ## Build
 
 ```bash
-# build for amd64
-docker build . --build-arg ARCH=amd64 -t klutchell/unbound-dnscrypt
+# enable docker experimental mode
+export DOCKER_CLI_EXPERIMENTAL=enabled
 
-# build for arm64
-docker build . --build-arg ARCH=arm64 -t klutchell/unbound-dnscrypt
+# use buildx to build and load an amd64 image
+docker buildx build . --pull --platform linux/amd64 \
+  --tag klutchell/unbound-dnscrypt:latest --load
 
-# build for arm32v7
-docker build . --build-arg ARCH=arm32v7 -t klutchell/unbound-dnscrypt
+# use buildx to build and load an arm64 image
+docker buildx build . --pull --platform linux/arm64 \
+  --tag klutchell/unbound-dnscrypt:latest --load
 
-# build for arm32v6
-docker build . --build-arg ARCH=arm32v6 -t klutchell/unbound-dnscrypt
+# use buildx to build and load an arm32v7 image
+docker buildx build . --pull --platform linux/arm/v7 \
+  --tag klutchell/unbound-dnscrypt:latest --load
+
+# use buildx to build and load an arm32v6 image
+docker buildx build . --pull --platform linux/arm/v6 \
+  --tag klutchell/unbound-dnscrypt:latest --load
 ```
 
 ## Test
 
 ```bash
+# optionally enable qemu if testing an arch that does not match your host
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
 # run a detached unbound-dnscrypt container instance
 docker run --rm -d --name unbound-dnscrypt klutchell/unbound-dnscrypt
 
@@ -46,6 +56,20 @@ docker exec unbound-dnscrypt dig sigfail.verteiltesysteme.net @127.0.0.1 +dnssec
 
 # stop and remove the detached container instance
 docker stop unbound-dnscrypt
+```
+
+## Deploy
+
+Requires `docker login` to authenticate with your provided repo tag.
+
+```bash
+# enable docker experimental mode
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+# use buildx to build and push a multiarch manifest
+docker buildx build . --pull \
+  --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 \
+  --tag klutchell/unbound-dnscrypt:latest --push
 ```
 
 ## Usage


### PR DESCRIPTION
When building with buildkit (such as buildx) we have a number of
platform args made available in the global scope.

https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope

By using these we can switch between rootfs base images and avoid the need
for qemu emulation when compiling with buildroot.

Change-type: minor
Signed-off-by: Kyle Harding <kyle@balena.io>