### PR TITLE
root-hints: include external root.hints file

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Use unbound-dnscrypt as upstream DNS for [Pi-Hole](https://pi-hole.net/).
 # run unbound-dnscrypt and bind to port 5053 to avoid conflicts with pihole on port 53
 docker run -d --name unbound-dnscrypt \
   --restart=unless-stopped \
-  -p 5053:53/tcp -p 5053:53/udp \
+  -p 5335:53/tcp -p 5335:53/udp \
   klutchell/unbound-dnscrypt
 
 # run pihole and bind to host network with 127.0.0.1:5053 as DNS1/DNS2
@@ -124,8 +124,8 @@ docker run -d --name pihole \
     -e ServerIP=your_IP_here \
     -e TZ=time_zone_here \
     -e WEBPASSWORD=Password \
-    -e DNS1=127.0.0.1#5053 \
-    -e DNS2=127.0.0.1#5053 \
+    -e DNS1=127.0.0.1#5335 \
+    -e DNS2=127.0.0.1#5335 \
     -v ~/pihole/:/etc/pihole/ \
     --dns=127.0.0.1 \
     --dns=1.1.1.1 \
@@ -159,15 +159,15 @@ services:
       - 'ServerIP=192.168.8.8'
       - 'TZ=America/Toronto'
       - 'WEBPASSWORD=secretpassword'
-      - 'DNS1=127.0.0.1#5053'
-      - 'DNS2=127.0.0.1#5053'
+      - 'DNS1=127.0.0.1#5335'
+      - 'DNS2=127.0.0.1#5335'
       - 'INTERFACE=eth0'
       - 'DNSMASQ_LISTENING=eth0'
   unbound-dnscrypt:
     image: klutchell/unbound-dnscrypt
     ports:
-      - '5053:53/tcp'
-      - '5053:53/udp'
+      - '5335:53/tcp'
+      - '5335:53/udp'
 ```
 
 ## Contributing

--- a/rootfs_overlay/etc/unbound/root.hints
+++ b/rootfs_overlay/etc/unbound/root.hints
@@ -1,0 +1,92 @@
+;       This file holds the information on root name servers needed to 
+;       initialize cache of Internet domain name servers
+;       (e.g. reference this file in the "cache  .  <file>"
+;       configuration file of BIND domain name servers). 
+; 
+;       This file is made available by InterNIC 
+;       under anonymous FTP as
+;           file                /domain/named.cache 
+;           on server           FTP.INTERNIC.NET
+;       -OR-                    RS.INTERNIC.NET
+; 
+;       last update:     January 11, 2021 
+;       related version of root zone:     2021011101
+; 
+; FORMERLY NS.INTERNIC.NET 
+;
+.                        3600000      NS    A.ROOT-SERVERS.NET.
+A.ROOT-SERVERS.NET.      3600000      A     198.41.0.4
+A.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:ba3e::2:30
+; 
+; FORMERLY NS1.ISI.EDU 
+;
+.                        3600000      NS    B.ROOT-SERVERS.NET.
+B.ROOT-SERVERS.NET.      3600000      A     199.9.14.201
+B.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:200::b
+; 
+; FORMERLY C.PSI.NET 
+;
+.                        3600000      NS    C.ROOT-SERVERS.NET.
+C.ROOT-SERVERS.NET.      3600000      A     192.33.4.12
+C.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2::c
+; 
+; FORMERLY TERP.UMD.EDU 
+;
+.                        3600000      NS    D.ROOT-SERVERS.NET.
+D.ROOT-SERVERS.NET.      3600000      A     199.7.91.13
+D.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2d::d
+; 
+; FORMERLY NS.NASA.GOV
+;
+.                        3600000      NS    E.ROOT-SERVERS.NET.
+E.ROOT-SERVERS.NET.      3600000      A     192.203.230.10
+E.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:a8::e
+; 
+; FORMERLY NS.ISC.ORG
+;
+.                        3600000      NS    F.ROOT-SERVERS.NET.
+F.ROOT-SERVERS.NET.      3600000      A     192.5.5.241
+F.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2f::f
+; 
+; FORMERLY NS.NIC.DDN.MIL
+;
+.                        3600000      NS    G.ROOT-SERVERS.NET.
+G.ROOT-SERVERS.NET.      3600000      A     192.112.36.4
+G.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:12::d0d
+; 
+; FORMERLY AOS.ARL.ARMY.MIL
+;
+.                        3600000      NS    H.ROOT-SERVERS.NET.
+H.ROOT-SERVERS.NET.      3600000      A     198.97.190.53
+H.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:1::53
+; 
+; FORMERLY NIC.NORDU.NET
+;
+.                        3600000      NS    I.ROOT-SERVERS.NET.
+I.ROOT-SERVERS.NET.      3600000      A     192.36.148.17
+I.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fe::53
+; 
+; OPERATED BY VERISIGN, INC.
+;
+.                        3600000      NS    J.ROOT-SERVERS.NET.
+J.ROOT-SERVERS.NET.      3600000      A     192.58.128.30
+J.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:c27::2:30
+; 
+; OPERATED BY RIPE NCC
+;
+.                        3600000      NS    K.ROOT-SERVERS.NET.
+K.ROOT-SERVERS.NET.      3600000      A     193.0.14.129
+K.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fd::1
+; 
+; OPERATED BY ICANN
+;
+.                        3600000      NS    L.ROOT-SERVERS.NET.
+L.ROOT-SERVERS.NET.      3600000      A     199.7.83.42
+L.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:9f::42
+; 
+; OPERATED BY WIDE
+;
+.                        3600000      NS    M.ROOT-SERVERS.NET.
+M.ROOT-SERVERS.NET.      3600000      A     202.12.27.33
+M.ROOT-SERVERS.NET.      3600000      AAAA  2001:dc3::35
+; End of file

--- a/rootfs_overlay/etc/unbound/unbound.conf
+++ b/rootfs_overlay/etc/unbound/unbound.conf
@@ -1,57 +1,103 @@
 # https://linux.die.net/man/5/unbound.conf
+# https://docs.pi-hole.net/guides/unbound/
 
 server:
+    # Enable or disable whether the unbound server forks into the background
+    # as a daemon. Default is yes.
+    do-daemonize: no
 
-	# Listen on all ipv4 interfaces, answer queries from the local subnet.
+    # If given, after binding the port the user privileges are dropped.
+    # Default is "unbound". If you give username: "" no user change is performed.
+    username: "unbound"
+
+    # No need to chroot as this container has been stripped of all other binaries.
+    chroot: ""
+
+    # If "" is given, logging goes to stderr, or nowhere once daemonized.
+    logfile: ""
+
+    # The process id is written to the file. Not required since we are running
+    # in a container with one process.
+    pidfile: ""
+
+    # The verbosity number, level 0 means no verbosity, only errors.
+    # Level 1 gives operational information.
+    # Level 2 gives detailed operational information.
+    # Level 3 gives query level information, output per query.
+    # Level 4 gives algorithm level information.
+    # Level 5 logs client identification for cache misses.
+    # Default is level 1. The verbosity can also be increased from the commandline.
+    verbosity: 1
+
+    # Listen on all ipv4 interfaces, answer queries from the local subnet.
     interface: 0.0.0.0
-	
-	# The port number, default 53, on which the server responds to queries. 
-	port: 53
 
-	# Enable or disable whether ip6 queries are answered or issued.
-	# Default is yes. If disabled, queries are not answered on IPv6,
-	# and queries are not sent on IPv6 to the internet nameservers.
-	do-ip6: no
+    # The port number, default 53, on which the server responds to queries.
+    port: 53
 
-	# Enable or disable whether the unbound server forks into the background
-	# as a daemon. Default is yes. 
-	do-daemonize: no
+    do-ip4: yes
+    do-udp: yes
+    do-tcp: yes
+    do-ip6: no
 
-	# If given, after binding the port the user privileges are dropped.
-	# Default is "unbound". If you give username: "" no user change is performed. 
-	username: "unbound"
+    # You want to leave this to no unless you have *native* IPv6. With 6to4 and
+    # Terredo tunnels your web browser should favor IPv4 for the same reasons
+    prefer-ip6: no
 
-	# No need to chroot as this container has been stripped of all other binaries.
-	chroot: ""
+    # Trust glue only if it is within the server's authority
+    harden-glue: yes
 
-	# The netblock is given as an IP4 or IP6 address with /size appended for a
-	# classless network block. The action can be deny, refuse, allow or allow_snoop. 
-	access-control: 127.0.0.1/32 allow
-	access-control: 192.168.0.0/16 allow
-	access-control: 172.16.0.0/12 allow
-	access-control: 10.0.0.0/8 allow
+    # Require DNSSEC data for trust-anchored zones, if such data is absent, the zone becomes BOGUS
+    harden-dnssec-stripped: yes
 
-	# If "" is given, logging goes to stderr, or nowhere once daemonized.
-	logfile: ""
+    # Don't use Capitalization randomization as it known to cause DNSSEC issues sometimes
+    # see https://discourse.pi-hole.net/t/unbound-stubby-or-dnscrypt-proxy/9378 for further details
+    use-caps-for-id: no
 
-	# The process id is written to the file. Not required since we are running
-	# in a container with one process.
-	pidfile: ""
+    # Reduce EDNS reassembly buffer size.
+    # Suggested by the unbound man page to reduce fragmentation reassembly problems
+    edns-buffer-size: 1472
 
-	# The verbosity number, level 0 means no verbosity, only errors.
-	# Level 1 gives operational information.
-	# Level 2 gives detailed operational information.
-	# Level 3 gives query level information, output per query. 
-	# Level 4 gives algorithm level information.
-	# Level 5 logs client identification for cache misses.
-	# Default is level 1. The verbosity can also be increased from the commandline.
-	verbosity: 1
+    # Perform prefetching of close to expired message cache entries
+    # This only applies to domains that have been frequently queried
+    prefetch: yes
 
-	# File with trust anchor for one zone, which is tracked with RFC5011 probes.
-	# The probes are several times per month, thus the machine must be online frequently.
-	# The initial file can be one with contents as described in trust-anchor-file.
-	# The file is written to when the anchor is updated, so the unbound user must
-	# have write permission.
-	auto-trust-anchor-file: /etc/unbound/root.key
-	
-	include: /etc/unbound/a-records.conf
+    # One thread should be sufficient, can be increased on beefy machines.
+    # In reality for most users running on small networks or on a single machine,
+    # it should be unnecessary to seek performance enhancement by increasing num-threads above 1.
+    num-threads: 1
+
+    # Ensure kernel buffer is large enough to not lose messages in traffic spikes
+    # (requires CAP_NET_ADMIN or privileged)
+    # so-rcvbuf: 1m
+
+    # The netblock is given as an IP4 or IP6 address with /size appended for a
+    # classless network block. The action can be deny, refuse, allow or allow_snoop.
+    access-control: 127.0.0.1/32 allow
+    access-control: 192.168.0.0/16 allow
+    access-control: 172.16.0.0/12 allow
+    access-control: 10.0.0.0/8 allow
+
+    # Ensure privacy of local IP ranges
+    private-address: 192.168.0.0/16
+    private-address: 169.254.0.0/16
+    private-address: 172.16.0.0/12
+    private-address: 10.0.0.0/8
+    private-address: fd00::/8
+    private-address: fe80::/10
+
+    # Read  the  root  hints from this file. Default is nothing, using built in
+    # hints for the IN class. The file has the format of  zone files,  with  root
+    # nameserver  names  and  addresses  only. The default may become outdated,
+    # when servers change,  therefore  it is good practice to use a root-hints
+    # file.  get one from https://www.internic.net/domain/named.root
+    root-hints: /etc/unbound/root.hints
+
+    # File with trust anchor for one zone, which is tracked with RFC5011 probes.
+    # The probes are several times per month, thus the machine must be online frequently.
+    # The initial file can be one with contents as described in trust-anchor-file.
+    # The file is written to when the anchor is updated, so the unbound user must
+    # have write permission.
+    auto-trust-anchor-file: /etc/unbound/root.key
+
+    include: /etc/unbound/a-records.conf


### PR DESCRIPTION
Avoid cases where the default root hints may be out-of-date
by inluding our own copy in the overlay. This can be updated
more easily at build time, or at runtime.

eg. wget https://www.internic.net/domain/named.root -O root.hints

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>