### PR TITLE
Switch from musl to glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #syntax=docker/dockerfile:1.2
 
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM debian:bullseye-20211201 AS buildroot-base
+FROM --platform=$BUILDPLATFORM debian:bullseye-20211220-slim AS buildroot-base
 
 # hadolint ignore=DL3008
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ WORKDIR /home/br-user/buildroot
 
 ARG TARGETARCH
 ARG TARGETVARIANT
-ARG ROOTFS_LIBC=musl
+ARG ROOTFS_LIBC=glibc
 
 COPY *.patch ./
 

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ export DOCKER_BUILDKIT=1
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # build local image for native platform
-docker build . --pull --tag klutchell/unbound --load
+docker build . --tag klutchell/unbound
 
 # cross-build for another platform
-docker build . --pull --tag klutchell/unbound --load --platform linux/arm/v6
+docker build . --tag klutchell/unbound --platform linux/arm/v6
 ```
 
 ## Test


### PR DESCRIPTION
Fix compatibility with Raspberry Pi OS (buster) on ARM.

- https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0#time64_requirements
- https://musl.libc.org/time64.html

See: https://github.com/klutchell/unbound-docker/issues/29