### PR TITLE
Switch from musl to glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ WORKDIR /home/br-user/buildroot
 
 ARG TARGETARCH
 ARG TARGETVARIANT
-ARG ROOTFS_LIBC=musl
+ARG ROOTFS_LIBC=glibc
 
 COPY *.patch ./
 


### PR DESCRIPTION
Attempt to fix compatibility with Raspberry Pi OS (buster) on ARM.

- https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0#time64_requirements
- https://musl.libc.org/time64.html

See: https://github.com/klutchell/unbound-docker/issues/29

Signed-off-by: Kyle Harding <kyle@balena.io>