### PR TITLE
Use libevent to allow file descriptors above 1024

### DIFF
--- a/0001-package-unbound-use-system-libevent.patch
+++ b/0001-package-unbound-use-system-libevent.patch
@@ -1,0 +1,30 @@
+From bf8694f6b0b1234fa7cb59611ee66d15000bd5a5 Mon Sep 17 00:00:00 2001
+From: Kyle Harding <kyle@balena.io>
+Date: Thu, 17 Mar 2022 09:26:31 -0400
+Subject: [PATCH 1/1] package/unbound: use system libevent
+
+The file descriptor limit when using the builtin mini-event
+cannot handle more than 1024 file descriptors.
+
+https://unbound.docs.nlnetlabs.nl/en/latest/topics/performance.html?highlight=libevent#using-libevent
+
+Signed-off-by: Kyle Harding <kyle@balena.io>
+---
+ package/unbound/unbound.mk | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/package/unbound/unbound.mk b/package/unbound/unbound.mk
+index 1e6e0d99d7..782ed2b049 100644
+--- a/package/unbound/unbound.mk
++++ b/package/unbound/unbound.mk
+@@ -17,6 +17,7 @@ UNBOUND_CONF_OPTS = \
+ 	--with-pidfile=/var/run/unbound.pid \
+ 	--with-rootkey-file=/etc/unbound/root.key \
+ 	--enable-tfo-server \
++	--with-libevent=$(STAGING_DIR)/usr \
+ 	--with-libexpat=$(STAGING_DIR)/usr \
+ 	--with-ssl=$(STAGING_DIR)/usr
+ 
+-- 
+2.30.2
+

--- a/rootfs_overlay/etc/unbound/unbound.conf
+++ b/rootfs_overlay/etc/unbound/unbound.conf
@@ -113,4 +113,17 @@ server:
     # have write permission.
     auto-trust-anchor-file: /etc/unbound/root.key
 
+    # Number of ports to open. This number of file descriptors can be opened per thread.
+    # Must be at least 1. Default depends on compile options. Larger numbers need extra
+    # resources from the operating system. For performance a very large value is best,
+    # use libevent to make this possible.
+    outgoing-range: 8192
+
+    # The number of queries that every thread will service simultaneously. If more queries
+    # arrive that need servicing, and no queries can be jostled out (see jostle-timeout),
+    # then the queries are dropped. This forces the client to resend after a timeout;
+    # allowing the server time to work on the existing queries. Default depends on
+    # compile options, 512 or 1024.
+    num-queries-per-thread: 4096
+
     include: /etc/unbound/a-records.conf


### PR DESCRIPTION
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/klutchell/unbound-docker/issues/54