### PR TITLE
unbound.conf: Include toplevel for custom configuration

### DIFF
--- a/rootfs_overlay/etc/unbound/unbound.conf
+++ b/rootfs_overlay/etc/unbound/unbound.conf
@@ -1,8 +1,6 @@
 # https://linux.die.net/man/5/unbound.conf
 # https://docs.pi-hole.net/guides/unbound/
 
-include: /etc/unbound/custom.conf.d/*.conf
-
 server:
     # Enable or disable whether the unbound server forks into the background
     # as a daemon. Default is yes.
@@ -127,3 +125,5 @@ server:
     # allowing the server time to work on the existing queries. Default depends on
     # compile options, 512 or 1024.
     num-queries-per-thread: 4096
+
+include-toplevel: /etc/unbound/custom.conf.d/*.conf


### PR DESCRIPTION
This allows custom files to override any default values.

Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/klutchell/unbound-docker/issues/70