### PR TITLE
Update unbound.conf: remove do-ip6: no statement

### DIFF
--- a/rootfs_overlay/etc/unbound/unbound.conf
+++ b/rootfs_overlay/etc/unbound/unbound.conf
@@ -38,7 +38,6 @@ server:
     do-ip4: yes
     do-udp: yes
     do-tcp: yes
-    do-ip6: no
 
     # You want to leave this to no unless you have *native* IPv6. With 6to4 and
     # Terredo tunnels your web browser should favor IPv4 for the same reasons


### PR DESCRIPTION
Remove `do-ip6: no` to avoid limitations of Unbound functionality.
Can be configured as 'no' in custom conf file.