### PR TITLE
Add performance settings to unbound.conf

### DIFF
--- a/rootfs_overlay/etc/unbound/unbound.conf
+++ b/rootfs_overlay/etc/unbound/unbound.conf
@@ -74,6 +74,9 @@ server:
     # This only applies to domains that have been frequently queried
     prefetch: yes
 
+    # Fetch DS records earlier (DNSSEC): more cpu usage, less latency
+    prefetch-key: yes
+    
     # One thread should be sufficient, can be increased on beefy machines.
     # In reality for most users running on small networks or on a single machine,
     # it should be unnecessary to seek performance enhancement by increasing num-threads above 1.
@@ -82,6 +85,15 @@ server:
     # Ensure kernel buffer is large enough to not lose messages in traffic spikes
     # (requires CAP_NET_ADMIN or privileged)
     # so-rcvbuf: 1m
+
+    # Increase cache size to utilize more RAM
+    msg-cache-size: 64m
+    rrset-cache-size: 128m
+
+    # This attempts to reduce latency by serving the outdated record before
+    # updating it instead of the other way around
+    # Default: cache-min-ttl: 0
+    serve-expired: yes
 
     # The netblock is given as an IP4 or IP6 address with /size appended for a
     # classless network block. The action can be deny, refuse, allow or allow_snoop.


### PR DESCRIPTION
The added settings increase the performance. I have tried a lot and these settings offer a significant improvement.

Another optimization would be:

```
auth-zone:
    # Get data for all TLDs by IXFR (or AXFR) from root servers
    # these are the only servers that answer an IXFR query
    name: "."
    primary: 199.9.14.201         # b.root-servers.net
    primary: 192.33.4.12          # c.root-servers.net
    primary: 199.7.91.13          # d.root-servers.net
    primary: 192.5.5.241          # f.root-servers.net
    primary: 192.112.36.4         # g.root-servers.net
    primary: 193.0.14.129         # k.root-servers.net
    primary: 192.0.47.132         # xfr.cjr.dns.icann.org
    primary: 192.0.32.132         # xfr.lax.dns.icann.org
    
    fallback-enabled: yes
    for-downstream: no
    for-upstream: yes
    
    zonefile: /var/lib/unbound/root.zone
```		
#52 

My Unbound conf: https://github.com/hagezi/files/blob/main/unbound/server.conf