### PR TITLE
Use official buildroot base image

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -30,8 +30,3 @@ jobs:
         linux/arm/v6
       dockerhub_repo: klutchell/unbound
       ghcr_repo: klutchell/unbound
-      docker_cache_from: |
-        docker.io/klutchell/unbound:main
-        ghcr.io/klutchell/unbound:main
-        docker.io/klutchell/unbound:latest
-        ghcr.io/klutchell/unbound:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,7 @@
 #syntax=docker/dockerfile:1.2
 
-# set by buildkit (DOCKER_BUILDKIT=1)
-# hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM debian:bullseye-20211220-slim AS buildroot-base
-
-# hadolint ignore=DL3008
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        bc \
-        build-essential \
-        ca-certificates \
-        cmake \
-        cpio \
-        file \
-        git \
-        locales \
-        python3 \
-        rsync \
-        unzip \
-        wget && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# hadolint ignore=DL3059
-RUN sed -i 's/# \(en_US.UTF-8\)/\1/' /etc/locale.gen && \
-    /usr/sbin/locale-gen && \
-	useradd -ms /bin/bash br-user && \
-    chown -R br-user:br-user /home/br-user
-
-USER br-user
-
-WORKDIR /home/br-user
-
-ENV HOME=/home/br-user
-
-ENV LC_ALL=en_US.UTF-8
+# platform set by buildkit (DOCKER_BUILDKIT=1)
+FROM --platform=$BUILDPLATFORM buildroot/base:20211120.1925 AS buildroot-base
 
 ARG BR_VERSION=2022.02.2
 


### PR DESCRIPTION
This should avoid full rebuilds when upstream debian
packages change.

Signed-off-by: Kyle Harding <kyle@balena.io>