### PR TITLE
Use `dnssec.works` instead of `verteiltesysteme.net` for tests

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   flowzone:
     name: Flowzone
-    uses: product-os/flowzone/.github/workflows/flowzone.yml@master
+    uses: product-os/flowzone/.github/workflows/flowzone.yml@kyle/combine-docker-jobs
     secrets:
       FLOWZONE_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
       GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -60,11 +60,14 @@ docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2 --reset -p yes
 # run a detached unbound container
 docker run --rm -d --name unbound klutchell/unbound
 
-# run dig with dnssec to test an example NOERROR endpoint
-docker exec unbound dig sigok.verteiltesysteme.net @127.0.0.1 +dnssec
+# run dig with dnssec to test NOERROR
+docker exec unbound dig @127.0.0.1 dnssec.works +dnssec +multi
 
-# run dig with dnssec to test an example SERVFAIL endpoint
-docker exec unbound dig sigfail.verteiltesysteme.net @127.0.0.1 +dnssec
+# run dig with dnssec to test SERVFAIL
+docker exec unbound dig @127.0.0.1 fail01.dnssec.works +dnssec +multi
+docker exec unbound dig @127.0.0.1 fail02.dnssec.works +dnssec +multi
+docker exec unbound dig @127.0.0.1 fail03.dnssec.works +dnssec +multi
+docker exec unbound dig @127.0.0.1 fail04.dnssec.works +dnssec +multi
 
 # stop and remove the container
 docker stop unbound

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -18,8 +18,8 @@ target "default" {
   cache-from = [
     "ghcr.io/klutchell/unbound:latest",
     "docker.io/klutchell/unbound:latest",
-    "ghcr.io/klutchell/unbound:master",
-    "docker.io/klutchell/unbound:master",
+    "ghcr.io/klutchell/unbound:main",
+    "docker.io/klutchell/unbound:main",
     "type=registry,ref=ghcr.io/klutchell/unbound:buildkit-cache-${base64encode(GITHUB_REF_NAME)},mode=max"
   ]
   cache-to = [

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -6,7 +6,7 @@ variable "GITHUB_REPOSITORY" {
   default = "klutchell/unbound-docker"
 }
 
-target "server" {
+target "default" {
   context = "./"
   dockerfile = "Dockerfile"
   platforms = [

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -7,24 +7,17 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    networks:
-      - internal
-    command: -v -v -v
+    command: -v -v
 
   version:
     image: localhost:5000/sut
     build:
       context: .
       dockerfile: Dockerfile
-    networks:
-      - internal
     command: -V
-    restart: always
 
   sut:
     image: alpine:3.16
-    networks:
-      - internal
     depends_on:
       - server
       - version
@@ -33,8 +26,8 @@ services:
       /bin/sh -c '
       apk add --no-cache bind-tools &&
       dig @server dnssec.works +dnssec +multi | tee /dev/stderr | grep -wq NOERROR &&
-      dig @server fail01.dnssec.works +dnssec +multi | tee /dev/stderr | grep -wq SERVFAIL &&
-      dig @server fail02.dnssec.works +dnssec +multi | tee /dev/stderr | grep -wq SERVFAIL &&
-      dig @server fail03.dnssec.works +dnssec +multi | tee /dev/stderr | grep -wq SERVFAIL &&
-      dig @server fail04.dnssec.works +dnssec +multi | tee /dev/stderr | grep -wq SERVFAIL
+      dig @server fail01.dnssec.works +dnssec +multi +time=120 | tee /dev/stderr | grep -wq SERVFAIL &&
+      dig @server fail02.dnssec.works +dnssec +multi +time=120 | tee /dev/stderr | grep -wq SERVFAIL &&
+      dig @server fail03.dnssec.works +dnssec +multi +time=120 | tee /dev/stderr | grep -wq SERVFAIL &&
+      dig @server fail04.dnssec.works +dnssec +multi +time=120 | tee /dev/stderr | grep -wq SERVFAIL
       '

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -32,6 +32,9 @@ services:
     command: >-
       /bin/sh -c '
       apk add --no-cache bind-tools &&
-      dig sigok.verteiltesysteme.net @server +dnssec | tee /dev/stderr | grep -wq NOERROR &&
-      dig sigfail.verteiltesysteme.net @server +dnssec | tee /dev/stderr | grep -wq SERVFAIL
+      dig @server dnssec.works +dnssec +multi | tee /dev/stderr | grep -wq NOERROR &&
+      dig @server fail01.dnssec.works +dnssec +multi | tee /dev/stderr | grep -wq SERVFAIL &&
+      dig @server fail02.dnssec.works +dnssec +multi | tee /dev/stderr | grep -wq SERVFAIL &&
+      dig @server fail03.dnssec.works +dnssec +multi | tee /dev/stderr | grep -wq SERVFAIL &&
+      dig @server fail04.dnssec.works +dnssec +multi | tee /dev/stderr | grep -wq SERVFAIL
       '

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,3 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    networks:
-      - internal
-    
-networks:
-  internal: {}

--- a/examples/pi-hole/docker-compose.yml
+++ b/examples/pi-hole/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       default:
         ipv4_address: 172.28.0.2
     healthcheck:
-      test: ["CMD", "dig", "-p", "53", "sigok.verteiltesysteme.net", "@127.0.0.1"]
+      test: ["CMD", "dig", "-p", "53", "dnssec.works", "@127.0.0.1"]
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
As the latter broke [1], this PR updates the tests to use a different DNSSEC validation service: https://dnssec.works

[1] https://github.com/pi-hole/FTL/pull/1469#issuecomment-1307718167

Signed-off-by: Kyle Harding <kyle@balena.io>