### PR TITLE
Remove port setting and specify the interface with port

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,6 +10,8 @@ services:
     volumes:
       # enable send-client-subnet example configuration file
       - ./rootfs_overlay/etc/unbound/custom.conf.d/send-client-subnet.conf.example:/etc/unbound/custom.conf.d/send-client-subnet.conf:ro
+      # enable custom-port example configuration file
+      - ./rootfs_overlay/etc/unbound/custom.conf.d/custom-port.conf.example:/etc/unbound/custom.conf.d/custom-port.conf:ro
     command: -v -v
 
   sut:
@@ -44,15 +46,15 @@ services:
 
         sleep 5
 
-        docker exec $${server_id} drill @127.0.0.1 -p 53 dnssec.works | tee /dev/stderr | grep NOERROR
-        ! docker exec $${server_id} drill @127.0.0.1 -p 53 foo.local | tee /dev/stderr | grep NOERROR
-        ! docker exec $${server_id} drill @127.0.0.1 -p 53 bar.local | tee /dev/stderr | grep NOERROR
+        docker exec $${server_id} drill @127.0.0.1 -p 5353 dnssec.works | tee /dev/stderr | grep NOERROR
+        ! docker exec $${server_id} drill @127.0.0.1 -p 5353 foo.local | tee /dev/stderr | grep NOERROR
+        ! docker exec $${server_id} drill @127.0.0.1 -p 5353 bar.local | tee /dev/stderr | grep NOERROR
 
-        dig @server -p 53 dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
-        ! dig @server -p 53 fail01.dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
-        ! dig @server -p 53 fail02.dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
-        ! dig @server -p 53 fail03.dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
-        ! dig @server -p 53 fail04.dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
+        dig @server -p 5353 dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
+        ! dig @server -p 5353 fail01.dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
+        ! dig @server -p 5353 fail02.dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
+        ! dig @server -p 5353 fail03.dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
+        ! dig @server -p 5353 fail04.dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
 
         # test ECS
-        dig @server -p 53 TXT o-o.myaddr.l.google.com +short | tee /dev/stderr | grep edns0-client-subnet
+        dig @server -p 5353 TXT o-o.myaddr.l.google.com +short | tee /dev/stderr | grep edns0-client-subnet

--- a/rootfs_overlay/etc/unbound/custom.conf.d/custom-port.conf.example
+++ b/rootfs_overlay/etc/unbound/custom.conf.d/custom-port.conf.example
@@ -1,0 +1,2 @@
+server:
+    interface: 0.0.0.0@5353

--- a/rootfs_overlay/etc/unbound/unbound.conf
+++ b/rootfs_overlay/etc/unbound/unbound.conf
@@ -29,11 +29,11 @@ server:
     # Default is level 1. The verbosity can also be increased from the commandline.
     verbosity: 1
 
-    # Listen on all ipv4 interfaces, answer queries from the local subnet.
-    interface: 0.0.0.0
-
-    # The port number, default 53, on which the server responds to queries.
-    port: 53
+    # Specify the interfaces to answer queries from by ip-address.
+    # The default is to listen to localhost (127.0.0.1 and ::1).
+    # specify 0.0.0.0 and ::0 to bind to all available interfaces.
+    # specify every interface[@port] on a new 'interface:' labelled line.
+    interface: 0.0.0.0@53
 
     do-ip4: yes
     do-udp: yes


### PR DESCRIPTION
The port setting is a default and cannot be overridden
with custom configurations, instead we should append to the
list of listen interfaces while specifying the port.

See: https://github.com/klutchell/unbound-docker/issues/221