### PR TITLE
Remove hardcoded port from default interface

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -46,9 +46,9 @@ services:
 
         sleep 5
 
-        docker exec $${server_id} drill @127.0.0.1 -p 5353 dnssec.works | tee /dev/stderr | grep NOERROR
-        ! docker exec $${server_id} drill @127.0.0.1 -p 5353 foo.local | tee /dev/stderr | grep NOERROR
-        ! docker exec $${server_id} drill @127.0.0.1 -p 5353 bar.local | tee /dev/stderr | grep NOERROR
+        docker exec $${server_id} drill -p 5353 dnssec.works @127.0.0.1 | tee /dev/stderr | grep NOERROR
+        ! docker exec $${server_id} drill -p 5353 foo.local @127.0.0.1 | tee /dev/stderr | grep NOERROR
+        ! docker exec $${server_id} drill -p 5353 bar.local @127.0.0.1 | tee /dev/stderr | grep NOERROR
 
         dig @server -p 5353 dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
         ! dig @server -p 5353 fail01.dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR

--- a/rootfs_overlay/etc/unbound/custom.conf.d/custom-port.conf.example
+++ b/rootfs_overlay/etc/unbound/custom.conf.d/custom-port.conf.example
@@ -1,2 +1,3 @@
 server:
-    interface: 0.0.0.0@5353
+    port: 5353
+    verbosity: 2

--- a/rootfs_overlay/etc/unbound/unbound.conf
+++ b/rootfs_overlay/etc/unbound/unbound.conf
@@ -33,7 +33,7 @@ server:
     # The default is to listen to localhost (127.0.0.1 and ::1).
     # specify 0.0.0.0 and ::0 to bind to all available interfaces.
     # specify every interface[@port] on a new 'interface:' labelled line.
-    interface: 0.0.0.0@53
+    interface: 0.0.0.0
 
     do-ip4: yes
     do-udp: yes


### PR DESCRIPTION
See: https://github.com/klutchell/unbound-docker/issues/221
Resolves: https://github.com/klutchell/unbound-docker/issues/350