### PR TITLE
Update to Unbound 1.19.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,9 @@ FROM build-base AS unbound
 
 WORKDIR /src
 
-ARG UNBOUND_VERSION=1.19.1
-# https://nlnetlabs.nl/downloads/unbound/unbound-1.19.1.tar.gz.sha256
-ARG UNBOUND_SHA256="bc1d576f3dd846a0739adc41ffaa702404c6767d2b6082deb9f2f97cbb24a3a9"
+ARG UNBOUND_VERSION=1.19.2
+# https://nlnetlabs.nl/downloads/unbound/unbound-1.19.2.tar.gz.sha256
+ARG UNBOUND_SHA256="cc560d345734226c1b39e71a769797e7fdde2265cbb77ebce542704bba489e55"
 
 ADD https://nlnetlabs.nl/downloads/unbound/unbound-${UNBOUND_VERSION}.tar.gz unbound.tar.gz
 

--- a/rootfs_overlay/etc/unbound/unbound.conf.example
+++ b/rootfs_overlay/etc/unbound/unbound.conf.example
@@ -1,7 +1,7 @@
 #
 # Example configuration file.
 #
-# See unbound.conf(5) man page, version 1.19.1.
+# See unbound.conf(5) man page, version 1.19.2.
 #
 # this is a comment.
 


### PR DESCRIPTION
[Unbound 1.19.2](https://github.com/NLnetLabs/unbound/releases/tag/release-1.19.2)

This security release fixes CVE-2024-1931.

NLnet Labs Unbound version 1.18.0 up to and including version 1.19.1
contain a vulnerability that can cause denial of service by a certain
code path that can lead to an infinite loop.

Unbound 1.18.0 introduced a feature that removes EDE records from
responses with size higher than the client's advertised buffer size.
Before removing all the EDE records however, it would try to see if
trimming the extra text fields on those records would result in an
acceptable size while still retaining the EDE codes.
Due to an unchecked condition, the code that trims the text of the EDE
records could loop indefinitely.
This happens when Unbound would reply with attached EDE information on a
positive reply and the client's buffer size is smaller than the needed
space to include EDE records.

The vulnerability can only be triggered when the 'ede: yes' option is
used; non default configuration.

From version 1.19.2 on, the code is fixed to avoid looping indefinitely.

We would like to thank Fredrik Pettai and Patrik Lundin from SUNET for
notifying us about the issue and working with us to identify the
vulnerability.

Bug Fixes:

Fix CVE-2024-1931, Denial of service when trimming EDE text on
positive replies.

Resolves: https://github.com/klutchell/unbound-docker/issues/368
