### PR TITLE
Added option to enable CacheDB Module with Redis backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,id=apk-cache-${TARGETARCH},target=/var/cache/apk \
 	libevent-dev \
 	libsodium-dev \
 	openssl-dev \
-    hiredis-dev \
+	hiredis-dev \
 	expat-dev
 
 ARG UNBOUND_UID=101
@@ -85,7 +85,7 @@ RUN ./configure \
 	--enable-subnet \
 	--with-pthreads \
 	--with-libevent \
-    --with-libhiredis \
+	--with-libhiredis \
 	--with-ssl \
 	--with-username=unbound
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN --mount=type=cache,id=apk-cache-${TARGETARCH},target=/var/cache/apk \
 	libevent-dev \
 	libsodium-dev \
 	openssl-dev \
+    hiredis-dev \
 	expat-dev
 
 ARG UNBOUND_UID=101
@@ -84,6 +85,7 @@ RUN ./configure \
 	--enable-subnet \
 	--with-pthreads \
 	--with-libevent \
+    --with-libhiredis \
 	--with-ssl \
 	--with-username=unbound
 
@@ -118,7 +120,7 @@ FROM scratch AS final
 COPY --from=build-base /lib/ld-musl*.so.1 /lib/
 COPY --from=build-base /usr/lib/libgcc_s.so.1 /usr/lib/
 COPY --from=build-base /lib/libcrypto.so.3 /lib/libssl.so.3 /lib/
-COPY --from=build-base /usr/lib/libsodium.so.* /usr/lib/libevent-2.1.so.* /usr/lib/libexpat.so.* /usr/lib/
+COPY --from=build-base /usr/lib/libsodium.so.* /usr/lib/libevent-2.1.so.* /usr/lib/libexpat.so.* /usr/lib/libhiredis.so.* /usr/lib/
 COPY --from=build-base /etc/ssl/ /etc/ssl/
 COPY --from=build-base /etc/passwd /etc/group /etc/
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ docker run --name unbound \
   klutchell/unbound
 ```
 
+## Optional: Enable CacheDB Module with Redis backend
+
+The cache DB module was compiled into daemon, but is disabled by default. To enable this module, follow this steps:
+* Modify [unbound.conf](https://unbound.docs.nlnetlabs.nl/en/latest/manpages/unbound.conf.html#cache-db-module-options) to add the following directive:
+ > module-config: "validator cachedb iterator"
+
+* Create a `cachedb.conf` under your custom configuration directory `/path/to/config/custom.conf.d` with Redis credentials:
+
+```bash
+cachedb:
+  backend: "redis"
+  redis-server-host: redis
+  redis-server-port: 6379
+  redis-expire-records: yes
+```
+Files must be readable by user/group `101:102` or world.
+
 Examples of docker-compose usage can be found in [examples](examples).
 
 ## License

--- a/rootfs_overlay/etc/unbound/custom.conf.d/cachedb.conf.example
+++ b/rootfs_overlay/etc/unbound/custom.conf.d/cachedb.conf.example
@@ -1,0 +1,5 @@
+cachedb:
+  backend: "redis"
+  redis-server-host: redis
+  redis-server-port: 6379
+  redis-expire-records: yes


### PR DESCRIPTION
Added option to enable CacheDB Module with Redis backend.

How to use:
The Cache DB module must be configured in the (unbound.conf) module-config: directive, e.g.: module-config: "validator cachedb iterator"

Additionally, must be created cachedb.conf file under custom.conf.d directory with Redis credentials.
Resolves: https://github.com/klutchell/unbound-docker/issues/372