### PR TITLE
Unbound release 1.20.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,9 +59,9 @@ FROM build-base AS unbound
 
 WORKDIR /src
 
-ARG UNBOUND_VERSION=1.19.3
-# https://nlnetlabs.nl/downloads/unbound/unbound-1.19.3.tar.gz.sha256
-ARG UNBOUND_SHA256="3ae322be7dc2f831603e4b0391435533ad5861c2322e34a76006a9fb65eb56b9"
+ARG UNBOUND_VERSION=1.20.0
+# https://nlnetlabs.nl/downloads/unbound/unbound-1.20.0.tar.gz.sha256
+ARG UNBOUND_SHA256="56b4ceed33639522000fd96775576ddf8782bb3617610715d7f1e777c5ec1dbf"
 
 ADD https://nlnetlabs.nl/downloads/unbound/unbound-${UNBOUND_VERSION}.tar.gz unbound.tar.gz
 

--- a/rootfs_overlay/etc/unbound/unbound.conf.example
+++ b/rootfs_overlay/etc/unbound/unbound.conf.example
@@ -1,7 +1,7 @@
 #
 # Example configuration file.
 #
-# See unbound.conf(5) man page, version 1.19.3.
+# See unbound.conf(5) man page, version @version@.
 #
 # this is a comment.
 
@@ -191,6 +191,21 @@ server:
 	# are behind a slow satellite link, to eg. 1128.
 	# unknown-server-time-limit: 376
 
+	# msec before recursion replies are dropped. The work item continues.
+	# discard-timeout: 1900
+
+	# Max number of replies waiting for recursion per IP address.
+	# wait-limit: 1000
+
+	# Max replies waiting for recursion for IP address with cookie.
+	# wait-limit-cookie: 10000
+
+	# Apart from the default, the wait limit can be set for a netblock.
+	# wait-limit-netblock: 192.0.2.0/24 50000
+
+	# Apart from the default, the wait limit with cookie can be adjusted.
+	# wait-limit-cookie-netblock: 192.0.2.0/24 50000
+
 	# the amount of memory to use for the RRset cache.
 	# plain value in bytes or you can append k, m or G. default is "4Mb".
 	# rrset-cache-size: 4m
@@ -210,6 +225,11 @@ server:
 
 	# the time to live (TTL) value cap for negative responses in the cache
 	# cache-max-negative-ttl: 3600
+
+	# the time to live (TTL) value lower bound, in seconds. Default 0.
+	# For negative responses in the cache. If disabled, default,
+	# cache-min-tll applies if configured.
+	# cache-min-negative-ttl: 0
 
 	# the time to live (TTL) value for cached roundtrip times, lameness and
 	# EDNS version information for hosts. In seconds.
@@ -283,7 +303,8 @@ server:
 	# Enable EDNS TCP keepalive option.
 	# edns-tcp-keepalive: no
 
-	# Timeout for EDNS TCP keepalive, in msec.
+	# Timeout for EDNS TCP keepalive, in msec. Overrides tcp-idle-timeout
+	# if edns-tcp-keepalive is set.
 	# edns-tcp-keepalive-timeout: 120000
 
 	# UDP queries that have waited in the socket buffer for a long time
@@ -303,6 +324,7 @@ server:
 	# Choose deny (drop message), refuse (polite error reply),
 	# allow (recursive ok), allow_setrd (recursive ok, rd bit is forced on),
 	# allow_snoop (recursive and nonrecursive ok)
+	# allow_cookie (allow UDP with valid cookie or stateful transport)
 	# deny_non_local (drop queries unless can be answered from local-data)
 	# refuse_non_local (like deny_non_local but polite error reply).
 	# access-control: 127.0.0.0/8 allow
@@ -401,19 +423,19 @@ server:
 	# How to do this is specific to your OS.
 	#
 	# If you give "" no chroot is performed. The path must not end in a /.
-	# chroot: "/var/unbound"
+	# chroot: "@UNBOUND_CHROOT_DIR@"
 
 	# if given, user privileges are dropped (after binding port),
 	# and the given username is assumed. Default is user "unbound".
 	# If you give "" no privileges are dropped.
-	# username: "unbound"
+	# username: "@UNBOUND_USERNAME@"
 
 	# the working directory. The relative files in this config are
 	# relative to this directory. If you give "" the working directory
 	# is not changed.
 	# If you give a server: directory: dir before include: file statements
 	# then those includes can be relative to the working directory.
-	# directory: "/var/unbound"
+	# directory: "@UNBOUND_RUN_DIR@"
 
 	# the log file, "" means log to stderr.
 	# Use of this option sets use-syslog to "no".
@@ -441,6 +463,9 @@ server:
 	# filtering log-queries and log-replies from the log.
 	# log-tag-queryreply: no
 
+	# log with destination address, port and type for log-replies.
+	# log-destaddr: no
+
 	# log the local-zone actions, like local-zone type inform is enabled
 	# also for the other local zone types.
 	# log-local-actions: no
@@ -449,7 +474,7 @@ server:
 	# log-servfail: no
 
 	# the pid file. Can be an absolute path outside of chroot/work dir.
-	# pidfile: "/var/unbound/unbound.pid"
+	# pidfile: "@UNBOUND_PIDFILE@"
 
 	# file to read root hints from.
 	# get one from https://www.internic.net/domain/named.cache
@@ -615,7 +640,7 @@ server:
 	# And then enable the auto-trust-anchor-file config item.
 	# Please note usage of unbound-anchor root anchor is at your own risk
 	# and under the terms of our LICENSE (see that file in the source).
-	# auto-trust-anchor-file: "/var/unbound/root.key"
+	# auto-trust-anchor-file: "@UNBOUND_ROOTKEY_FILE@"
 
 	# trust anchor signaling sends a RFC8145 key tag query after priming.
 	# trust-anchor-signaling: yes
@@ -983,6 +1008,13 @@ server:
 	# if 0(default) it is disabled, otherwise states qps allowed per ip address
 	# ip-ratelimit: 0
 
+	# global query ratelimit for all ip addresses with a valid DNS Cookie.
+	# feature is experimental.
+	# if 0(default) it is disabled, otherwise states qps allowed per ip address
+	# useful in combination with 'allow_cookie'.
+	# If used, suggested to be higher than ip-ratelimit, tenfold.
+	# ip-ratelimit-cookie: 0
+
 	# ip ratelimits are tracked in a cache, size in bytes of cache (or k,m).
 	# ip-ratelimit-size: 4m
 	# ip ratelimit cache slabs, reduces lock contention if equal to cpucount.
@@ -1003,6 +1035,14 @@ server:
 	# fast-server-permil: 0
 	# the number of servers that will be used in the fast server selection.
 	# fast-server-num: 3
+
+	# reply to requests containing DNS Cookies as specified in RFC 7873 and RFC 9018.
+	# answer-cookie: no
+
+	# secret for DNS Cookie generation.
+	# useful for anycast deployments.
+	# example value "000102030405060708090a0b0c0d0e0f".
+	# cookie-secret: <128 bit random hex string>
 
 	# Enable to attach Extended DNS Error codes (RFC8914) to responses.
 	# ede: no
@@ -1056,7 +1096,7 @@ server:
 # o and give a python-script to run.
 python:
 	# Script file to load
-	# python-script: "/var/unbound/ubmodule-tst.py"
+	# python-script: "@UNBOUND_SHARE_DIR@/ubmodule-tst.py"
 
 # Dynamic library config section. To enable:
 # o use --with-dynlibmodule to configure before compiling.
@@ -1067,7 +1107,7 @@ python:
 #   the module-config then you need one dynlib-file per instance.
 dynlib:
 	# Script file to load
-	# dynlib-file: "/var/unbound/dynlib.so"
+	# dynlib-file: "@UNBOUND_SHARE_DIR@/dynlib.so"
 
 # Remote control config section.
 remote-control:
@@ -1090,16 +1130,16 @@ remote-control:
 	# control-use-cert: "yes"
 
 	# Unbound server key file.
-	# server-key-file: "/var/unbound/unbound_server.key"
+	# server-key-file: "@UNBOUND_RUN_DIR@/unbound_server.key"
 
 	# Unbound server certificate file.
-	# server-cert-file: "/var/unbound/unbound_server.pem"
+	# server-cert-file: "@UNBOUND_RUN_DIR@/unbound_server.pem"
 
 	# unbound-control key file.
-	# control-key-file: "/var/unbound/unbound_control.key"
+	# control-key-file: "@UNBOUND_RUN_DIR@/unbound_control.key"
 
 	# unbound-control certificate file.
-	# control-cert-file: "/var/unbound/unbound_control.pem"
+	# control-cert-file: "@UNBOUND_RUN_DIR@/unbound_control.pem"
 
 # Stub zones.
 # Create entries like below, to make all queries for 'example.com' and
@@ -1150,7 +1190,7 @@ remote-control:
 # sources of notifies.
 # auth-zone:
 #	name: "."
-#	primary: 199.9.14.201         # b.root-servers.net
+#	primary: 170.247.170.2        # b.root-servers.net
 #	primary: 192.33.4.12          # c.root-servers.net
 #	primary: 199.7.91.13          # d.root-servers.net
 #	primary: 192.5.5.241          # f.root-servers.net
@@ -1158,7 +1198,7 @@ remote-control:
 #	primary: 193.0.14.129         # k.root-servers.net
 #	primary: 192.0.47.132         # xfr.cjr.dns.icann.org
 #	primary: 192.0.32.132         # xfr.lax.dns.icann.org
-#	primary: 2001:500:200::b      # b.root-servers.net
+#	primary: 2801:1b8:10::b       # b.root-servers.net
 #	primary: 2001:500:2::c        # c.root-servers.net
 #	primary: 2001:500:2d::d       # d.root-servers.net
 #	primary: 2001:500:2f::f       # f.root-servers.net
@@ -1228,6 +1268,9 @@ remote-control:
 #     secret-seed: "default"
 #     # if the backend should be read from, but not written to.
 #     cachedb-no-store: no
+#     # if the cachedb should be checked before a serve-expired response is
+#     # given, when serve-expired is enabled.
+#     cachedb-check-when-serve-expired: yes
 #
 #     # For "redis" backend:
 #     # (to enable, use --with-libhiredis to configure before compiling)
@@ -1266,7 +1309,7 @@ remote-control:
 # 	dnstap-enable: no
 # 	# if set to yes frame streams will be used in bidirectional mode
 # 	dnstap-bidirectional: yes
-# 	dnstap-socket-path: ""
+# 	dnstap-socket-path: "@DNSTAP_SOCKET_PATH@"
 # 	# if "" use the unix socket in dnstap-socket-path, otherwise,
 # 	# set it to "IPaddress[@port]" of the destination.
 # 	dnstap-ip: ""


### PR DESCRIPTION
[Unbound 1.20.0
](https://github.com/NLnetLabs/unbound/releases/tag/release-1.20.0)
This release has a fix for the DNSBomb issue CVE-2024-33655. This has a
low severity for Unbound, since it makes Unbound complicit in targeting
others, but does not affect Unbound so much.

To mitigate the issue new configuration options are introduced.
The options discard-timeout: 1900, wait-limit: 1000
and wait-limit-cookie: 10000 are enabled by default. They limit the
number of outstanding queries that a querier can have. This limits
the reply pulse, and make Unbound less favorable for the issue.
With the config wait-limit-netblock and wait-limit-cookie-netblock
the parameters can be fine tuned for specific destinations.
More information on the attack and Unbound's mitigations are
presented further down.

Other fixes in this release are that Unbound no longer follows symlinks
when truncating the pidfile. Unbound also does not chown the pidfile,
this is for safety reasons. There are also a number of fixes for RPZ, in
handling CNAMEs. There is a memory leak fix for the edns client subnet
cache. For DNSSEC validation a case is fixed when the query is of type
DNAME. The unbound-anchor program is fixed to first write to a temporary
file, before replacing the original. This handles disk full situations,
and because of it unbound-anchor needs permission to create that file,
in the same directory as the original file. There is also a fix for
IP_DONTFRAG, to disable fragmentation instead of the opposite.

The option cache-min-negative-ttl can be used to set the minimum TTL
for negative responses in the cache. It complements existing options to
set the maximum ttl for negative responses and to set the minimum and
maximum ttl but not specifically for negative responses.

The option cachedb-check-when-serve-expired option makes Unbound use
cachedb to check for expired responses, when serve-expired is enabled,
and cachedb is used. It is enabled by default.

The -q option for unbound-checkconf can be added to silence it when
there are no errors.

The DNSBomb vulnerability CVE-2024-33655.

== Summary
The DNSBomb attack, via specially timed DNS queries and answers, can
cause a Denial of Service on resolvers and spoofed targets.

Unbound itself is not vulnerable for DoS, rather it can be used to take
part in a pulsing DoS amplification attack.

Unbound 1.20.0 includes fixes so the impact of the DoS from Unbound
is significantly lower than it used to be and making the attack, and
Unbound's participation, less tempting for attackers.

== Affected products
Unbound up to and including 1.19.3.

== Description
The DNSBomb attack works by sending low-rate spoofed queries for a
malicious zone to Unbound. By controlling the delay of the malicious
authoritative answers, Unbound slowly accumulates pending answers for
the spoofed addresses. When the authoritative answers become available
to Unbound at the same time, Unbound starts serving all the accumulated
queries. This results into large-sized, concentrated response bursts to
the spoofed addresses.

From version 1.20.0 on, Unbound introduces a couple of configuration
options to help mitigate the impact.
Their complete description can be found in the included manpages but
they are also briefly listed here together with their default values for
convenience:

discard-timeout: 1900
After 1900 ms a reply to the client will be dropped.
Unbound would still work on the query but refrain from replying in
order to not accumulate a huge number of "old" replies.
Legitimate clients retry on timeouts.

wait-limit: 1000
wait-limit-cookie: 10000
Limits the amount of client queries that require recursion
(cache-hits are not counted) per IP address. More recursive queries
than the allowed limit are dropped. Clients with a valid EDNS Cookie
can have a different limit, higher by default.
wait-limit: 0 disables all wait limits.

wait-limit-netblock
wait-limit-cookie-netblock
These do not have a default value but they can fine grain
configuration for specific netblocks. With or without EDNS Cookies.

The options above are trying to shrink the DNSBomb window so that the
impact of the DoS from Unbound is significantly lower than it used to be
and making the attack, and Unbound's participation, less tempting for
attackers.

== Acknowledgements
We would like to thank Xiang Li from the Network and Information
Security Lab of Tsinghua University for discovering and disclosing the
attack.

Features

The config for discard-timeout, wait-limit, wait-limit-cookie,
wait-limit-netblock and wait-limit-cookie-netblock was added, for
the fix to the DNSBomb issue.
Merge https://github.com/NLnetLabs/unbound/pull/1027: Introduce 'cache-min-negative-ttl' option.
Merge https://github.com/NLnetLabs/unbound/pull/1043 from xiaoxiaoafeifei: Add loongarch support; updates
config.guess(2024-01-01) and config.sub(2024-01-01), verified
with upstream.
Implement cachedb-check-when-serve-expired: yes option, default
is enabled. When serve expired is enabled with cachedb, it first
checks cachedb before serving the expired response.
Fix https://github.com/NLnetLabs/unbound/issues/876: [FR] can unbound-checkconf be silenced when configuration
is valid?
Bug Fixes

Fix for the DNSBomb vulnerability CVE-2024-33655. Thanks to Xiang Li
from the Network and Information Security Lab of Tsinghua University
for reporting it.
Update doc/unbound.doxygen with 'doxygen -u'. Fixes option
deprecation warnings and updates with newer defaults.
Remove unused portion from iter_dname_ttl unit test.
Fix validator classification of qtype DNAME for positive and
redirection answers, and fix validator signature routine for dealing
with the synthesized CNAME for a DNAME without previously
encountering it and also for when the qtype is DNAME.
Fix qname minimisation for reply with a DNAME for qtype CNAME that
answers it.
Fix doc test so it ignores but outputs unsupported doxygen options.
Fix https://github.com/NLnetLabs/unbound/issues/1021 Inconsistent Behavior with Changing rpz-cname-override
and doing a unbound-control reload.
Merge https://github.com/NLnetLabs/unbound/pull/1028: Clearer documentation for tcp-idle-timeout and
edns-tcp-keepalive-timeout.
Fix https://github.com/NLnetLabs/unbound/issues/1029: rpz trigger clientip and action rpz-passthru not working
as expected.
Fix rpz that the rpz override is taken in case of clientip triggers.
Fix that the clientip passthru action is logged. Fix that the
clientip localdata action is logged. Fix rpz override action cname
for the clientip trigger.
Fix to unify codepath for local alias for rpz cname action override.
Fix rpz for cname override action after nsdname and nsip triggers.
Fix that addrinfo is not kept around but copied and freed, so that
log-destaddr uses a copy of the information, much like NSD does.
Merge https://github.com/NLnetLabs/unbound/pull/1030: Persist the openssl and expat directories for repeated
Windows builds.
Fix that rpz CNAME content is limited to the max number of cnames.
Fix rpz, it follows iterator CNAMEs for nsip and nsdname and sets
the reply query_info values, that is better for debug logging.
Fix rpz that copies the cname override completely to the temp
region, so there are no references to the rpz region.
Add rpz unit test for nsip action override.
Fix rpz for qtype CNAME after nameserver trigger.
Fix rpz so that rpz CNAME can apply after rpz CNAME. And fix that
clientip and nsip can give a CNAME.
Fix localdata and rpz localdata to match CNAME only if no direct
type match is available.
Merge https://github.com/NLnetLabs/unbound/pull/831 from Pierre4012: Improve Windows NSIS installer
script (setup.nsi).
For https://github.com/NLnetLabs/unbound/pull/831: Format text, use exclamation icon and explicit label
names.
Fix name of unit test for subnet cache response.
Fix https://github.com/NLnetLabs/unbound/issues/1032: The size of subnet_msg_cache calculation mistake cause
memory usage increased beyond expectations.
Fix for https://github.com/NLnetLabs/unbound/issues/1032, add safeguard to make table space positive.
Fix comment in lruhash space function.
Fix to add unit test for lruhash space that exercises the routines.
Fix that when the server truncates the pidfile, it does not follow
symbolic links.
Fix that the server does not chown the pidfile.
Fix https://github.com/NLnetLabs/unbound/issues/1034: DoT forward-zone via unbound-control.
Fix for crypto related failures to have a better error string.
Fix https://github.com/NLnetLabs/unbound/issues/1035: Potential Bug while parsing port from the "stub-host"
string; also affected forward-zones and remote-control host
directives.
Fix https://github.com/NLnetLabs/unbound/issues/369: dnstap showing extra responses; for client responses
right from the cache when replying with expired data or
prefetching.
Fix https://github.com/NLnetLabs/unbound/pull/1040: fix heap-buffer-overflow issue in function cfg_mark_ports
of file util/config_file.c.
For https://github.com/NLnetLabs/unbound/pull/1040: adjust error text and disallow negative ports in other
parts of cfg_mark_ports.
Fix comment syntax for view function views_find_view.
Fix https://github.com/NLnetLabs/unbound/issues/595: unbound-anchor cannot deal with full disk; it will now
first write out to a temp file before replacing the original one,
like Unbound already does for auto-trust-anchor-file.
Fixup compile without cachedb.
Add test for cachedb serve expired.
Extended test for cachedb serve expired.
Fix makefile dependencies for fake_event.c.
Fix cachedb for serve-expired with serve-expired-reply-ttl.
Fix to not reply serve expired unless enabled for cachedb.
Fix cachedb for serve-expired with serve-expired-client-timeout.
Fixup unit test for cachedb server expired client timeout with
a check if response if from upstream or from cachedb.
Fixup cachedb to not refetch when serve-expired-client-timeout is
used.
Merge https://github.com/NLnetLabs/unbound/pull/1049 from Petr Menšík: Py_NoSiteFlag is not needed since
Python 3.8
Fix https://github.com/NLnetLabs/unbound/pull/1048: Update ax_pkg_swig.m4 and ax_pthread.m4.
Fix configure, autoconf for https://github.com/NLnetLabs/unbound/pull/1048.
Add checklock feature verbose_locking to trace locks and unlocks.
Fix edns subnet to sort rrset references when storing messages
in the cache. This fixes a race condition in the rrset locks.
Merge https://github.com/NLnetLabs/unbound/pull/1053: Remove child delegations from cache when grandchild
delegations are returned from parent.
Fix ci workflow for macos for moved install locations.
Fix configure flto check error, by finding grep for it.
Merge https://github.com/NLnetLabs/unbound/pull/1041: Stub and Forward unshare. This has one structure
for them and fixes https://github.com/NLnetLabs/unbound/issues/1038: fatal error: Could not initialize
thread / error: reading root hints.
Fix to disable fragmentation on systems with IP_DONTFRAG,
with a nonzero value for the socket option argument.
Fix doc unit test for out of directory build.
Fix cachedb with serve-expired-client-timeout disabled. The edns
subnet module deletes global cache and cachedb cache when it
stores a result, and serve-expired is enabled, so that the global
reply, that is older than the ecs reply, does not return after
the ecs reply expires.
Add unit tests for cachedb and subnet cache expired data.
Man page entry for unbound-checkconf -q.
Cleanup unnecessary strdup calls for EDE strings.
Fix doxygen comment for errinf_to_str_bogus.