### PR TITLE
Enable TCP Fast Open

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,8 @@ RUN ./configure \
 	--enable-dnscrypt \
 	--enable-subnet \
 	--enable-cachedb \
+	--enable-tfo-server \
+	--enable-tfo-client \
 	--with-pthreads \
 	--with-libevent \
 	--with-libhiredis \


### PR DESCRIPTION
Unbound supports the TCP Fast Open feature [0] which can be enabled at build time with:

--enable-tfo-client
--enable-tfo-server

TFO is generally considered as worthwhile feature and doesn't require any additional dependencies.

[0] https://lwn.net/Articles/508865/