### PR TITLE
Update the example health check

### DIFF
--- a/examples/pi-hole/docker-compose.yml
+++ b/examples/pi-hole/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       default:
         ipv4_address: 172.28.0.2
     healthcheck:
-      test: ["CMD", "dig", "-p", "53", "dnssec.works", "@127.0.0.1"]
+      test: ["CMD", "drill", "@127.0.0.1", "dnssec.works"]
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
With a check as part of the image, users don't have to configure the checks themselves in a Compose file, for example.