### PR TITLE
Remove the version top-level element from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2"
-
 services:
   server:
     build:

--- a/examples/pi-hole/docker-compose.yml
+++ b/examples/pi-hole/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2"
-
 volumes:
   pihole:
   dnsmasq:


### PR DESCRIPTION
The version top-level element is obsolete: https://docs.docker.com/reference/compose-file/version-and-name/