### PR TITLE
Enable support for DNS-over-HTTPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN --mount=type=cache,id=apk-cache-${TARGETARCH},target=/var/cache/apk \
 	ca-certificates-bundle \
 	libevent-dev \
 	libsodium-dev \
+	nghttp2-dev \
 	openssl-dev \
 	hiredis-dev \
 	expat-dev
@@ -91,6 +92,7 @@ RUN ./configure \
 	--with-pthreads \
 	--with-libevent \
 	--with-libhiredis \
+	--with-libnghttp2 \
 	--with-ssl \
 	--with-username=unbound
 
@@ -142,7 +144,7 @@ FROM scratch AS final
 COPY --from=build-base /lib/ld-musl*.so.1 /lib/
 COPY --from=build-base /usr/lib/libgcc_s.so.1 /usr/lib/
 COPY --from=build-base /lib/libcrypto.so.3 /lib/libssl.so.3 /lib/
-COPY --from=build-base /usr/lib/libsodium.so.* /usr/lib/libevent-2.1.so.* /usr/lib/libexpat.so.* /usr/lib/libhiredis.so.* /usr/lib/
+COPY --from=build-base /usr/lib/libsodium.so.* /usr/lib/libevent-2.1.so.* /usr/lib/libexpat.so.* /usr/lib/libhiredis.so.* /usr/lib/libnghttp2.so.* /usr/lib/
 COPY --from=build-base /etc/ssl/ /etc/ssl/
 COPY --from=build-base /etc/passwd /etc/group /etc/
 


### PR DESCRIPTION
Unbound needs to be compiled with libnghttp2 in order to provide DNS-over-HTTPS: https://github.com/NLnetLabs/unbound/blob/5e9b6296b7ab586eaa956f21b98c574967ceb06e/doc/unbound.conf.5.in#L583-L584