### PR TITLE
Add an example for unbound + redis

### DIFF
--- a/examples/redis/custom.conf.d/cachedb.conf
+++ b/examples/redis/custom.conf.d/cachedb.conf
@@ -1,0 +1,8 @@
+server:
+  module-config: "validator cachedb iterator"
+
+cachedb:
+  backend: "redis"
+  redis-server-host: redis
+  redis-server-port: 6379
+  redis-expire-records: yes

--- a/examples/redis/docker-compose.yml
+++ b/examples/redis/docker-compose.yml
@@ -1,0 +1,31 @@
+volumes:
+  redis:
+
+services:
+  redis:
+    image: redis:latest
+    container_name: redis
+    hostname: redis
+    restart: unless-stopped
+    volumes:
+      - redis:/data
+    healthcheck:
+      test: "[ $$(redis-cli ping) = 'PONG' ]"
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 30s
+
+  unbound:
+    image: klutchell/unbound
+    healthcheck:
+      test: ["CMD", "drill", "@127.0.0.1", "dnssec.works"]
+      interval: 30s
+      timeout: 30s
+      retries: 3
+      start_period: 30s
+    volumes:
+      - ./custom.conf.d:/etc/unbound/custom.conf.d:ro
+    restart: unless-stopped
+    depends_on:
+      - redis


### PR DESCRIPTION
Adds a Docker Compose project to illustrate how to use unbound with redis.