### PR TITLE
Ensure health check always returns 0 or 1

### DIFF
--- a/examples/pi-hole/docker-compose.yml
+++ b/examples/pi-hole/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       default:
         ipv4_address: 172.28.0.2
     healthcheck:
-      test: ["CMD", "drill", "@127.0.0.1", "dnssec.works"]
+      test: ["CMD", "drill", "@127.0.0.1", "dnssec.works", "||", "exit", "1"]
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
Dockerfile reference says that health checks should always return 0 or 1. Any other status code is reserved. Adding an "|| exit 1" will return a 1 anytime drill returns non-zero status