### PR TITLE
Add rust wrapper for drill to always exit 0 or 1

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -48,9 +48,9 @@ services:
 
         sleep 5
 
-        docker exec $${server_id} drill -p 5353 dnssec.works @127.0.0.1 | tee /dev/stderr | grep NOERROR
-        ! docker exec $${server_id} drill -p 5353 foo.local @127.0.0.1 | tee /dev/stderr | grep NOERROR
-        ! docker exec $${server_id} drill -p 5353 bar.local @127.0.0.1 | tee /dev/stderr | grep NOERROR
+        docker exec $${server_id} drillrs -p 5353 dnssec.works @127.0.0.1 | tee /dev/stderr | grep NOERROR
+        ! docker exec $${server_id} drillrs -p 5353 foo.local @127.0.0.1 | tee /dev/stderr | grep NOERROR
+        ! docker exec $${server_id} drillrs -p 5353 bar.local @127.0.0.1 | tee /dev/stderr | grep NOERROR
 
         dig @server -p 5353 dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
         ! dig @server -p 5353 fail01.dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR

--- a/drillrs/Cargo.toml
+++ b/drillrs/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "drillrs"
+# version = "0.0.1"
+# edition = "2021"
+
+[dependencies]

--- a/drillrs/src/main.rs
+++ b/drillrs/src/main.rs
@@ -1,0 +1,24 @@
+use std::process::{Command, ExitCode};
+
+fn main() -> ExitCode {
+    let mut child = match Command::new("/usr/bin/drill")
+        .args(std::env::args().skip(1))
+        .spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            eprintln!("Unable to launch drill process: {e:?}");
+            return ExitCode::from(1);
+        }
+    };
+
+    match child.wait() {
+        // Return 0 on 0 exit code
+        Ok(status) if status.success() => ExitCode::from(0),
+        // Return 1 on any other exit code
+        Ok(_) => ExitCode::from(1),
+        Err(e) => {
+            eprintln!("Error waiting for drill process to finish: {e:?}");
+            ExitCode::from(1)
+        }
+    }
+}

--- a/examples/pi-hole/docker-compose.yml
+++ b/examples/pi-hole/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       default:
         ipv4_address: 172.28.0.2
     healthcheck:
-      test: ["CMD", "drill", "@127.0.0.1", "dnssec.works"]
+      test: ["CMD", "drillrs", "@127.0.0.1", "dnssec.works"]
       interval: 30s
       timeout: 30s
       retries: 3

--- a/examples/redis/docker-compose.yml
+++ b/examples/redis/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   unbound:
     image: klutchell/unbound
     healthcheck:
-      test: ["CMD", "drill", "@127.0.0.1", "dnssec.works"]
+      test: ["CMD", "drillrs", "@127.0.0.1", "dnssec.works"]
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
Docker healthchecks expect processes to exit with 0 or 1, the other exit codes are reserved.

See: https://github.com/klutchell/unbound-docker/pull/502