### PR TITLE
fix: set serve-expired recommendations from rfc 8767

### DIFF
--- a/rootfs_overlay/etc/unbound/unbound.conf
+++ b/rootfs_overlay/etc/unbound/unbound.conf
@@ -95,6 +95,14 @@ server:
     # Default: cache-min-ttl: 0
     serve-expired: yes
 
+    # Limit serving of expired responses to configured seconds after expiration. 0 means disabled
+    # A suggested value per RFC 8767 is between 86400 (1 day) and 259200 (3 days).
+    serve-expired-ttl: 86400
+
+    # Time in milliseconds before replying to the client with expired data
+    # A recommended value per RFC 8767 is 1800
+    serve-expired-client-timeout: 1800
+
     # The netblock is given as an IP4 or IP6 address with /size appended for a
     # classless network block. The action can be deny, refuse, allow or allow_snoop.
     access-control: 127.0.0.1/32 allow


### PR DESCRIPTION
Resolves #522 

Set recommended serve-expired ttl's to follow rfc 8767