### PR TITLE
Use GitHub Hosted ARM runners in Public Preview

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,8 +1,0 @@
-# https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
-name: "Custom tests"
-description: "Run pre-commit hooks"
-runs:
-  using: "composite"
-  steps:
-    - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
-    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -36,3 +36,10 @@ jobs:
         ghcr.io/klutchell/unbound,
         klutchell/unbound
       toggle_auto_merge: false
+      docker_runs_on: >
+        {
+          "linux/amd64": ["ubuntu-24.04"],
+          "linux/arm64": ["ubuntu-24.04-arm"],
+          "linux/arm/v7": ["ubuntu-24.04-arm"],
+          "linux/arm/v6": ["ubuntu-24.04-arm"]
+        }

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -36,4 +36,3 @@ jobs:
         ghcr.io/klutchell/unbound,
         klutchell/unbound
       toggle_auto_merge: false
-      restrict_custom_actions: false


### PR DESCRIPTION

See: https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/choosing-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories