### PR TITLE
Update Unbound to release 1.23.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,8 +136,7 @@ People _love_ thorough bug reports. I'm not even kidding.
 
 4. Commit and push changes to `Dockerfile` and `unbound.conf.example`.
 
-[Here](https://github.com/klutchell/unbound-docker/pull/235) is an example pull
-request for reference.
+[Example pull request #235](https://github.com/klutchell/unbound-docker/pull/235) for reference.
 
 ## License
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,9 +64,9 @@ FROM build-base AS unbound
 
 WORKDIR /src
 
-ARG UNBOUND_VERSION=1.23.0
-# https://nlnetlabs.nl/downloads/unbound/unbound-1.23.0.tar.gz.sha256
-ARG UNBOUND_SHA256="959bd5f3875316d7b3f67ee237a56de5565f5b35fc9b5fc3cea6cfe735a03bb8"
+ARG UNBOUND_VERSION=1.23.1
+# https://nlnetlabs.nl/downloads/unbound/unbound-1.23.1.tar.gz.sha256
+ARG UNBOUND_SHA256="6a6b117c799d8de3868643397e0fd71591f6d42f4473f598bdb22609ff362590"
 
 ADD https://nlnetlabs.nl/downloads/unbound/unbound-${UNBOUND_VERSION}.tar.gz unbound.tar.gz
 

--- a/rootfs_overlay/etc/unbound/unbound.conf.example
+++ b/rootfs_overlay/etc/unbound/unbound.conf.example
@@ -1,7 +1,7 @@
 #
 # Example configuration file.
 #
-# See unbound.conf(5) man page, version 1.23.0.
+# See unbound.conf(5) man page, version 1.23.1.
 #
 # this is a comment.
 


### PR DESCRIPTION
This security release fixes the Rebirthday Attack https://github.com/advisories/GHSA-xrv5-2wwg-jp3r.

This re-opens up resolvers to a birthday paradox, for EDNS client subnet
servers that respond with non-ECS answers. It only affects Unbound when
compiled with --enable-subnet, and subnetmod is enabled with config
options that send ECS information to upstream servers.

The CVE is described here
https://nlnetlabs.nl/downloads/unbound/CVE-2025-5994.txt

See: https://github.com/NLnetLabs/unbound/releases/tag/release-1.23.1