### PR TITLE
Update Unbound to release v1.24.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,9 +64,9 @@ FROM build-base AS unbound
 
 WORKDIR /src
 
-ARG UNBOUND_VERSION=1.23.1
-# https://nlnetlabs.nl/downloads/unbound/unbound-1.23.1.tar.gz.sha256
-ARG UNBOUND_SHA256="6a6b117c799d8de3868643397e0fd71591f6d42f4473f598bdb22609ff362590"
+ARG UNBOUND_VERSION=1.24.0
+# https://nlnetlabs.nl/downloads/unbound/unbound-1.24.0.tar.gz.sha256
+ARG UNBOUND_SHA256="147b22983cc7008aa21007e251b3845bfcf899ffd2d3b269253ebf2e27465086"
 
 ADD https://nlnetlabs.nl/downloads/unbound/unbound-${UNBOUND_VERSION}.tar.gz unbound.tar.gz
 

--- a/rootfs_overlay/etc/unbound/unbound.conf.example
+++ b/rootfs_overlay/etc/unbound/unbound.conf.example
@@ -1,7 +1,7 @@
 #
 # Example configuration file.
 #
-# See unbound.conf(5) man page, version 1.23.1.
+# See unbound.conf(5) man page, version 1.24.0.
 #
 # this is a comment.
 
@@ -116,8 +116,8 @@ server:
 	# so-rcvbuf: 0
 
 	# buffer size for UDP port 53 outgoing (SO_SNDBUF socket option).
-	# 0 is system default.  Use 4m to handle spikes on very busy servers.
-	# so-sndbuf: 0
+	# 0 is system default. Set larger to handle spikes on very busy servers.
+	# so-sndbuf: 4m
 
 	# use SO_REUSEPORT to distribute queries over threads.
 	# at extreme load it could be better to turn it off to distribute even.
@@ -163,7 +163,7 @@ server:
 	# msg-cache-slabs: 4
 
 	# the number of queries that a thread gets to service.
-	# num-queries-per-thread: 1024
+	# num-queries-per-thread: 2048
 
 	# if very busy, 50% queries run to completion, 50% get timeout in msec
 	# jostle-timeout: 200
@@ -279,7 +279,7 @@ server:
 	# do-ip6: yes
 
 	# If running unbound on an IPv6-only host, domains that only have
-	# IPv4 servers would become unresolveable.  If NAT64 is available in
+	# IPv4 servers would become unresolvable.  If NAT64 is available in
 	# the network, unbound can use NAT64 to reach these servers with
 	# the following option.  This is NOT needed for enabling DNS64 on a
 	# system that has IPv4 connectivity.


### PR DESCRIPTION
This release features increased defaults, num.valops statistic, unbound-control cache_lookup, and bug fixes.

See: https://github.com/NLnetLabs/unbound/releases/tag/release-1.24.0