### PR TITLE
Update Unbound to release 1.24.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,9 +64,9 @@ FROM build-base AS unbound
 
 WORKDIR /src
 
-ARG UNBOUND_VERSION=1.24.1
-# https://nlnetlabs.nl/downloads/unbound/unbound-1.24.1.tar.gz.sha256
-ARG UNBOUND_SHA256="7f2b1633e239409619ae0527f67878b0f33ae0ec0ee5a3a51c042c359ba1eeab"
+ARG UNBOUND_VERSION=1.24.2
+# https://nlnetlabs.nl/downloads/unbound/unbound-1.24.2.tar.gz.sha256
+ARG UNBOUND_SHA256="44e7b53e008a6dcaec03032769a212b46ab5c23c105284aa05a4f3af78e59cdb"
 
 ADD https://nlnetlabs.nl/downloads/unbound/unbound-${UNBOUND_VERSION}.tar.gz unbound.tar.gz
 

--- a/rootfs_overlay/etc/unbound/unbound.conf.example
+++ b/rootfs_overlay/etc/unbound/unbound.conf.example
@@ -1,7 +1,7 @@
 #
 # Example configuration file.
 #
-# See unbound.conf(5) man page, version 1.24.1.
+# See unbound.conf(5) man page, version 1.24.2.
 #
 # this is a comment.
 


### PR DESCRIPTION
This security release has additional fixes for CVE-2025-11411.

See: https://github.com/NLnetLabs/unbound/releases/tag/release-1.24.2