### PR TITLE
Update Unbound to release 1.25.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,9 +64,9 @@ FROM build-base AS unbound
 
 WORKDIR /src
 
-ARG UNBOUND_VERSION=1.25.0
-# https://nlnetlabs.nl/downloads/unbound/unbound-1.25.0.tar.gz.sha256
-ARG UNBOUND_SHA256="062a6eda723fe2f041bee4079b76981569f1d12e066bbd74800242fc1ebddec7"
+ARG UNBOUND_VERSION=1.25.1
+# https://nlnetlabs.nl/downloads/unbound/unbound-1.25.1.tar.gz.sha256
+ARG UNBOUND_SHA256="0fe8b6277b0959cfd17562debac0aa5f71e0b02dc4ffa9c60271c583edab586f"
 
 ADD https://nlnetlabs.nl/downloads/unbound/unbound-${UNBOUND_VERSION}.tar.gz unbound.tar.gz
 

--- a/rootfs_overlay/etc/unbound/unbound.conf.example
+++ b/rootfs_overlay/etc/unbound/unbound.conf.example
@@ -1,7 +1,7 @@
 #
 # Example configuration file.
 #
-# See unbound.conf(5) man page, version 1.25.0.
+# See unbound.conf(5) man page, version 1.25.1.
 #
 # this is a comment.
 


### PR DESCRIPTION
This release has a number of security fixes.

See https://github.com/NLnetLabs/unbound/releases/tag/release-1.25.1