### PR TITLE
feat(example): Switch Redis to Valkey in the cachedb example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,21 +34,22 @@ docker run --name unbound \
   klutchell/unbound
 ```
 
-### Optional: Enable CacheDB Module with Redis backend
+### Optional: Enable CacheDB Module with Valkey (Redis-compatible) backend
 
 The cache DB module was compiled into daemon, but is disabled by default. To
 enable this module, follow this steps:
 
+- You will need a Redis-protocol-compatible backend (e.g. Redis or Valkey) running and reachable from the Unbound container; see [examples/redis](examples/redis) for a full docker-compose example;
 - Create a `cachedb.conf` under your custom configuration directory `/path/to/config/custom.conf.d`;
 - Add a `server` directive with module configuration to enable `cachedb` module;
-- Add a `cachedb` directive with Redis credentials;
+- Add a `cachedb` directive with Valkey (Redis-compatible) credentials;
 
 ```bash
 server:
   module-config: "validator cachedb iterator"
 cachedb:
   backend: "redis"
-  redis-server-host: redis
+  redis-server-host: valkey
   redis-server-port: 6379
   redis-expire-records: yes
 ```

--- a/examples/redis/custom.conf.d/cachedb.conf
+++ b/examples/redis/custom.conf.d/cachedb.conf
@@ -2,6 +2,6 @@ server:
   module-config: "validator cachedb iterator"
 cachedb:
   backend: "redis"
-  redis-server-host: redis
+  redis-server-host: valkey
   redis-server-port: 6379
   redis-expire-records: yes

--- a/examples/redis/docker-compose.yml
+++ b/examples/redis/docker-compose.yml
@@ -1,16 +1,22 @@
 volumes:
-  redis:
+  valkey:
 
 services:
-  redis:
-    image: redis:latest
-    container_name: redis
-    hostname: redis
+  valkey:
+    image: valkey/valkey:alpine
+    container_name: valkey
+    read_only: true
     restart: unless-stopped
+    command: >
+      valkey-server
+      --save 86400 1
+      --maxmemory 128mb
+      --maxmemory-policy allkeys-lru
+      --stop-writes-on-bgsave-error no
     volumes:
-      - redis:/data
+      - valkey:/data
     healthcheck:
-      test: "[ $$(redis-cli ping) = 'PONG' ]"
+      test: ["CMD", "valkey-cli", "ping"]
       interval: 30s
       timeout: 3s
       retries: 3
@@ -29,4 +35,4 @@ services:
       - ./custom.conf.d:/etc/unbound/custom.conf.d:ro
     restart: unless-stopped
     depends_on:
-      - redis
+      - valkey

--- a/rootfs_overlay/etc/unbound/custom.conf.d/cachedb.conf.example
+++ b/rootfs_overlay/etc/unbound/custom.conf.d/cachedb.conf.example
@@ -2,6 +2,6 @@ server:
   module-config: "validator cachedb iterator"
 cachedb:
   backend: "redis"
-  redis-server-host: redis
+  redis-server-host: valkey
   redis-server-port: 6379
   redis-expire-records: yes


### PR DESCRIPTION
As many projects are switching to Valkey, update the cachedb example accordingly.

## Changes

- Switch `image:` from `redis:latest` to `valkey/valkey:alpine`; a Debian-based Valkey image is unnecessary for this example.
- Change the `healthcheck` command from `[ $$(redis-cli ping) = 'PONG' ]` to `["CMD", "valkey-cli", "ping"]`.
- Add `read_only: true`; Valkey keeps write access through the `/data` volume while the rest of the container filesystem remains read-only.
- Start Valkey with `valkey-server --save 86400 1 --maxmemory 128mb --maxmemory-policy allkeys-lru --stop-writes-on-bgsave-error no`.
- Rename the example's service, container, volume, CLI, and user-facing text from Redis to Valkey, while retaining the Unbound `backend: "redis"` value, the `redis-server-*` directive names, and the `examples/redis` directory.
- Point both cachedb config examples (`examples/redis/custom.conf.d/cachedb.conf` and `rootfs_overlay/etc/unbound/custom.conf.d/cachedb.conf.example`) at the `valkey` service.
- Update the README CacheDB section to require a reachable Redis-protocol-compatible backend (see `examples/redis`) and rename the heading to "Optional: Enable CacheDB Module with Valkey (Redis-compatible) backend".
