### PR TITLE
Add automated Unbound bump and release-tag workflows

### DIFF
--- a/.github/workflows/bump-unbound.yml
+++ b/.github/workflows/bump-unbound.yml
@@ -1,0 +1,184 @@
+name: Bump Unbound
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Unbound version to bump to. Leave empty to auto-detect the latest upstream release."
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  bump:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.FLOWZONE_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Determine current and target version
+        id: versions
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          current=$(grep -oP '(?<=^ARG UNBOUND_VERSION=)\S+' Dockerfile)
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$INPUT_VERSION" ]; then
+            if ! echo "$INPUT_VERSION" | grep -qP '^\d+\.\d+\.\d+$'; then
+              echo "::error::version input '$INPUT_VERSION' doesn't look like an Unbound version (expected X.Y.Z)"
+              exit 1
+            fi
+            target="$INPUT_VERSION"
+          else
+            # NLnetLabs tags releases as release-X.Y.Z; strip the prefix to get the version
+            tag=$(curl -fsSL https://api.github.com/repos/NLnetLabs/unbound/releases/latest | jq -r .tag_name)
+            target="${tag#release-}"
+          fi
+          echo "target=$target" >> "$GITHUB_OUTPUT"
+          echo "Current: $current, target: $target"
+
+          # only proceed if target is strictly newer than current
+          newest=$(printf '%s\n%s' "$current" "$target" | sort -V | tail -n1)
+          if [ "$current" = "$target" ] || [ "$newest" != "$target" ]; then
+            echo "up_to_date=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "up_to_date=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for an existing bump branch/PR
+        if: steps.versions.outputs.up_to_date == 'false'
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TARGET: ${{ steps.versions.outputs.target }}
+        run: |
+          set -euo pipefail
+          count=$(gh pr list --repo "$REPO" --state open --search "head:bump/unbound-${TARGET}" --json number --jq 'length')
+          echo "exists=$([ "$count" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve upstream SHA256
+        if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        id: hash
+        env:
+          TARGET: ${{ steps.versions.outputs.target }}
+        run: |
+          set -euo pipefail
+          base="https://nlnetlabs.nl/downloads/unbound/unbound-${TARGET}.tar.gz"
+          # the published .sha256 sidecar is the canonical value pinned in the Dockerfile
+          sha256=$(curl -fsSL "${base}.sha256" | awk '{print $1}')
+          if ! echo "$sha256" | grep -qE '^[0-9a-f]{64}$'; then
+            echo "::error::published sha256 sidecar for ${TARGET} is not a 64-char hex digest: '$sha256'"
+            exit 1
+          fi
+          # defense in depth: confirm the tarball is actually mirrored and matches the sidecar
+          curl -fsSL "$base" -o /tmp/unbound.tar.gz
+          actual=$(sha256sum /tmp/unbound.tar.gz | awk '{print $1}')
+          if [ "$actual" != "$sha256" ]; then
+            echo "::error::tarball sha256 ${actual} does not match published sidecar ${sha256} for ${TARGET}"
+            exit 1
+          fi
+          echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Update Dockerfile
+        if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        env:
+          TARGET: ${{ steps.versions.outputs.target }}
+          SHA256: ${{ steps.hash.outputs.sha256 }}
+        run: |
+          set -euo pipefail
+          sed -i \
+            -e "s|^ARG UNBOUND_VERSION=.*|ARG UNBOUND_VERSION=${TARGET}|" \
+            -e "s|^# https://nlnetlabs.nl/downloads/unbound/unbound-.*\.tar\.gz\.sha256|# https://nlnetlabs.nl/downloads/unbound/unbound-${TARGET}.tar.gz.sha256|" \
+            -e "s|^ARG UNBOUND_SHA256=.*|ARG UNBOUND_SHA256=\"${SHA256}\"|" \
+            Dockerfile
+
+      - name: Set up Docker Buildx
+        if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Regenerate example config
+        if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        env:
+          DOCKER_BUILDKIT: "1"
+        run: docker build . --target conf-example --output rootfs_overlay/etc/unbound/
+
+      - name: Sanity build
+        if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        env:
+          DOCKER_BUILDKIT: "1"
+        run: docker build . --tag klutchell/unbound:bump-check
+
+      - name: Create commit via REST API
+        if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        id: commit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          TARGET: ${{ steps.versions.outputs.target }}
+        run: |
+          set -euo pipefail
+          branch="bump/unbound-${TARGET}"
+          base_sha=$(git rev-parse HEAD)
+          base_tree=$(gh api "repos/${REPO}/git/commits/${base_sha}" --jq .tree.sha)
+
+          tree_json="[]"
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            base64 -w0 "$f" > /tmp/blob.b64
+            blob_sha=$(gh api "repos/${REPO}/git/blobs" -f encoding=base64 -F content=@/tmp/blob.b64 --jq .sha)
+            tree_json=$(echo "$tree_json" | jq --arg path "$f" --arg sha "$blob_sha" '. + [{path: $path, mode: "100644", type: "blob", sha: $sha}]')
+          done < <(git status --porcelain | awk '{print $2}')
+
+          new_tree=$(jq -n --arg base_tree "$base_tree" --argjson tree "$tree_json" '{base_tree: $base_tree, tree: $tree}' \
+            | gh api "repos/${REPO}/git/trees" --input - --jq .sha)
+
+          message=$(printf '%s\n\n%s' "Bump Unbound to ${TARGET}" "See https://github.com/NLnetLabs/unbound/releases/tag/release-${TARGET}")
+          new_commit=$(jq -n --arg message "$message" --arg tree "$new_tree" --arg parent "$base_sha" \
+            '{message: $message, tree: $tree, parents: [$parent]}' \
+            | gh api "repos/${REPO}/git/commits" --input - --jq .sha)
+
+          gh api "repos/${REPO}/git/refs" -f ref="refs/heads/${branch}" -f sha="${new_commit}"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Open pull request
+        if: steps.versions.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          TARGET: ${{ steps.versions.outputs.target }}
+          BRANCH: ${{ steps.commit.outputs.branch }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' \
+            "Automated bump to [Unbound ${TARGET}](https://github.com/NLnetLabs/unbound/releases/tag/release-${TARGET})." \
+            "" \
+            "SHA256 taken from the published \`.tar.gz.sha256\` sidecar and re-verified against the tarball on this runner, \`rootfs_overlay/etc/unbound/unbound.conf.example\` regenerated via \`docker build --target conf-example\`, and a sanity build passed. See [CONTRIBUTING.md](https://github.com/${REPO}/blob/main/CONTRIBUTING.md#packaging-new-unbound-releases) for the process this follows." \
+            "" \
+            "Tagging the release remains a separate, gated step that runs after this PR merges." \
+            > /tmp/pr-body.md
+
+          gh pr create \
+            --repo "$REPO" \
+            --title "Bump Unbound to ${TARGET}" \
+            --body-file /tmp/pr-body.md \
+            --base main \
+            --head "$BRANCH"

--- a/.github/workflows/tag-unbound.yml
+++ b/.github/workflows/tag-unbound.yml
@@ -1,0 +1,112 @@
+name: Tag Unbound release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  tag:
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'bump/unbound-')
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.FLOWZONE_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Checkout merge commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ github.token }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Verify only expected files changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          changed=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
+          echo "Changed files:"
+          echo "$changed"
+          unexpected=$(echo "$changed" | grep -v -E '^(Dockerfile|rootfs_overlay/etc/unbound/unbound\.conf\.example)$' || true)
+          if [ -n "$unexpected" ]; then
+            echo "::error::Unexpected files changed in this bump PR, refusing to tag: $unexpected"
+            exit 1
+          fi
+
+      - name: Resolve content commit
+        id: commit
+        env:
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          # non-squash merges put the actual content on the merge commit's 2nd parent;
+          # squash merges make the merge commit itself the content commit (no 2nd parent)
+          if content_sha=$(git rev-parse --verify -q "${MERGE_SHA}^2"); then
+            echo "sha=$content_sha" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=$MERGE_SHA" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine version and re-verify SHA256
+        id: version
+        env:
+          CONTENT_SHA: ${{ steps.commit.outputs.sha }}
+        run: |
+          set -euo pipefail
+          git show "${CONTENT_SHA}:Dockerfile" > /tmp/Dockerfile.content
+          version=$(grep -oP '(?<=^ARG UNBOUND_VERSION=)\S+' /tmp/Dockerfile.content)
+          pinned_sha256=$(grep -oP '(?<=^ARG UNBOUND_SHA256=")[^"]+' /tmp/Dockerfile.content)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          actual_sha256=$(curl -fsSL "https://nlnetlabs.nl/downloads/unbound/unbound-${version}.tar.gz" | sha256sum | awk '{print $1}')
+          if [ "$actual_sha256" != "$pinned_sha256" ]; then
+            echo "::error::SHA256 mismatch for ${version}: Dockerfile pins ${pinned_sha256}, tarball is actually ${actual_sha256}. Refusing to tag."
+            exit 1
+          fi
+
+      - name: Check tag doesn't already exist
+        id: exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/${REPO}/git/ref/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tag via REST API
+        if: steps.exists.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ steps.version.outputs.version }}
+          CONTENT_SHA: ${{ steps.commit.outputs.sha }}
+        run: |
+          set -euo pipefail
+          now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          tag_sha=$(jq -n --arg tag "v${VERSION}" --arg message "v${VERSION}" --arg object "$CONTENT_SHA" --arg date "$now" \
+            '{tag: $tag, message: $message, object: $object, type: "commit", tagger: {name: "github-actions[bot]", email: "github-actions[bot]@users.noreply.github.com", date: $date}}' \
+            | gh api "repos/${REPO}/git/tags" --input - --jq .sha)
+
+          gh api "repos/${REPO}/git/refs" \
+            -f ref="refs/tags/v${VERSION}" \
+            -f sha="${tag_sha}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,12 @@ People _love_ thorough bug reports. I'm not even kidding.
 
 ## Packaging new Unbound releases
 
+> **Automated:** The [`Bump Unbound`](.github/workflows/bump-unbound.yml) workflow runs
+> weekly (and on demand via **Run workflow**). It detects new upstream releases, updates
+> the `ARG` fields below, regenerates the example config, sanity-builds the image, and
+> opens a `Bump Unbound to X.Y.Z` PR for review. The manual steps below are the fallback
+> for out-of-band bumps or when you want to drive it by hand.
+
 1. In your working copy, create a new branch if you haven't already, and update
    the following fields in the [Dockerfile](Dockerfile) with the new version and
    hash.
@@ -144,7 +150,7 @@ People _love_ thorough bug reports. I'm not even kidding.
 For the current pattern, see recent commits touching the Unbound `ARG` lines:
 
 ```bash
-git log --oneline -- Dockerfile | grep -i "update unbound" | head -5
+git log --oneline -- Dockerfile | grep -iE "bump unbound|update unbound" | head -5
 ```
 
 ## Tagging a release (maintainers only)
@@ -152,14 +158,21 @@ git log --oneline -- Dockerfile | grep -i "update unbound" | head -5
 This section applies to repository maintainers. Contributors do not need to tag
 releases — the maintainer will tag once your bump PR is merged.
 
+> **Automated:** When a `bump/unbound-*` PR merges, the
+> [`Tag Unbound release`](.github/workflows/tag-unbound.yml) workflow re-verifies the
+> pinned SHA256 against the upstream tarball and creates the `vX.Y.Z` tag on the content
+> commit automatically (an unsigned annotated tag), which triggers the image publish.
+> The manual, GPG-signed procedure below remains the fallback for releases cut outside
+> that flow.
+
 After an Unbound bump PR is merged to `main`, tag the release on the **content
-commit** (the "Update Unbound to release X.Y.Z" commit), not the merge commit
-GitHub creates on top.
+commit** (the "Bump Unbound to X.Y.Z" commit), not the merge commit GitHub creates
+on top.
 
 ```bash
 git fetch origin
 # Find the content commit on origin/main
-git log origin/main --grep='Update Unbound to release' --format='%H %s' -1
+git log origin/main --grep='Bump Unbound to' --format='%H %s' -1
 
 # Create a signed, annotated tag with the version as the message body
 git tag -s vX.Y.Z -m "vX.Y.Z" <content-commit-sha>


### PR DESCRIPTION
Mirrors the two workflows we just added to dnscrypt-proxy-docker.

- `bump-unbound` runs weekly (and on demand) — detects a new upstream release, updates the Dockerfile version + SHA256 ARGs, regenerates the conf-example, sanity-builds, and opens a `Bump Unbound to X.Y.Z` PR for review. Never auto-merges.
- `tag-unbound` fires when a `bump/unbound-*` PR merges — re-verifies the pinned SHA256 against the upstream tarball and tags `vX.Y.Z` on the content commit, which triggers the Flowzone image publish.

SHA256 comes from the published `.tar.gz.sha256` sidecar (re-verified against the tarball on the runner). Tagging is unsigned (bot-authored via REST), replacing the manual GPG-signed step for automated bumps; CONTRIBUTING.md keeps the manual process as the fallback.

Heads up: 1.25.2 is already out, so the first run will immediately open the bump PR.
