### PR TITLE
Fix flaky ECS test

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -55,5 +55,8 @@ services:
         ! dig @server -p 5353 fail03.dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
         ! dig @server -p 5353 fail04.dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
 
-        # test ECS
-        dig @server -p 5353 TXT o-o.myaddr.l.google.com +short | tee /dev/stderr | grep edns0-client-subnet
+        # test ECS. The client must supply the subnet: the container network is
+        # RFC1918, and authorities ignore a private prefix. Assert only that
+        # unbound echoes the option back, since whether an authority honours
+        # ECS (and therefore the returned scope) is not ours to control.
+        dig @server -p 5353 TXT o-o.myaddr.l.google.com +subnet=203.0.113.0/24 +nocmd | tee /dev/stderr | grep -E '; CLIENT-SUBNET: 203\.0\.113\.0/24/'


### PR DESCRIPTION
The ECS assertion grepped for `edns0-client-subnet`, which matches the substring inside Google's *negative* reply "edns0-client-subnet was not used". So the test's green state was Google telling us ECS was not used, and it never verified ECS at all.

The sut container's address is 172.18.0.2, so unbound forwards 172.18.0.0/24 upstream. Authorities won't use an RFC1918 prefix, hence the "was not used" answer. Whether that answer reaches the client is up to Google's anycast fleet: if the reply echoes the ECS option unbound keeps it and the substring matches, but if the reply omits the option unbound logs "Authority indicates no support", re-resolves without the subnet, and returns a single TXT record with no substring to match. Both are RFC 7871-legal, so re-running just rolled the dice again -- roughly half the Test docker jobs failed on this line, on every platform.

Have the client supply a routable prefix via +subnet instead, and assert that unbound echoes the option back. unbound returns a CLIENT-SUBNET option whenever the client sent one -- with the upstream scope, or scope 0 via cp_edns_bad_response when upstream declines -- so the assertion no longer depends on any authority's ECS policy. It also fails when the subnet module is absent, which the old one could not.