### PR TITLE
Assert ECS config locally rather than via an authority

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -55,8 +55,14 @@ services:
         ! dig @server -p 5353 fail03.dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
         ! dig @server -p 5353 fail04.dnssec.works +dnssec +multi | tee /dev/stderr | grep NOERROR
 
-        # test ECS. The client must supply the subnet: the container network is
-        # RFC1918, and authorities ignore a private prefix. Assert only that
-        # unbound echoes the option back, since whether an authority honours
-        # ECS (and therefore the returned scope) is not ours to control.
-        dig @server -p 5353 TXT o-o.myaddr.l.google.com +subnet=203.0.113.0/24 +nocmd | tee /dev/stderr | grep -E '; CLIENT-SUBNET: 203\.0\.113\.0/24/'
+        # Check the subnet module is built in and the send-client-subnet example
+        # config is active. A real ECS round-trip is deliberately not asserted
+        # here: authorities refuse non-routable prefixes, and whether they echo
+        # the option back varies between anycast instances. When they do not
+        # echo it, unbound re-resolves without the subnet and the answer reaches
+        # the client with no CLIENT-SUBNET option, so every client-visible ECS
+        # assertion is a coin flip. Testing the round-trip needs an
+        # authoritative server we control.
+        docker exec $${server_id} unbound -V | grep 'Linked modules:.*subnetcache'
+        docker logs $${server_id} 2>&1 | grep 'init module 0: subnetcache'
+        docker logs $${server_id} 2>&1 | grep 'send-client-subnet: 0\.0\.0\.0/0'


### PR DESCRIPTION
My previous change did not fix the flake, it moved it. Asserting on a CLIENT-SUBNET option in the client's answer still depends on whether the authority echoes ECS back, which is the same coin flip the original `grep edns0-client-subnet` rode on. Two runs of that assertion, same branch, minutes apart: amd64 saw `answer has edns subnet 203.0.113.0/24` twice and passed, arm64 saw it zero times and failed.

Two mistakes. 203.0.113.0/24 is TEST-NET-3, so it is no more routable than the RFC1918 address it replaced and authorities decline it just the same -- the failing job still got "edns0-client-subnet was not used". And unbound does not echo CLIENT-SUBNET to a client that sent one in general: subnetmod.c gates that on the client having sent a /0 prefix, so with a /24 the generate_lookup_without_subnet() fallback returns the answer with no option at all.

There is no client-visible ECS signal that survives an authority declining, so assert only local state: the build links subnetcache, the mounted example config puts it in the module chain, and send-client-subnet was parsed. The active unbound.conf sets no module-config, so "init module 0: subnetcache" appears only when the example file loaded -- which is what this test existed to check.

Verified by matching each pattern against captured output from seven real jobs, across four platforms and unbound 1.25.2 and 1.26.0, passing and failing. Testing an actual round-trip would need an authoritative server in the compose file; that is a larger change than this test has had.